### PR TITLE
Add a GitHub Action to push releases to PyPI

### DIFF
--- a/.github/workflows/pre-commit.yml
+++ b/.github/workflows/pre-commit.yml
@@ -3,15 +3,16 @@ name: pre-commit
 on:
   pull_request:
   push:
-    branches: [main]
+    branches:
+      - main
 
 jobs:
   pre-commit:
     runs-on: ubuntu-22.04
     steps:
-    - uses: actions/checkout@v3
-    - uses: actions/setup-python@v4
-      with:
-        python-version: "3.10"
-        cache: "pip"
-    - uses: pre-commit/action@v3.0.0
+      - uses: actions/checkout@v3
+      - uses: actions/setup-python@v4
+        with:
+          python-version: "3.11"
+          cache: "pip"
+      - uses: pre-commit/action@v3.0.0

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,23 @@
+name: release
+
+on:
+  workflow_run:
+    workflows:
+      - pre-commit
+    tags:
+      - "v*.*.*"
+    types:
+      - completed
+
+jobs:
+  release:
+    runs-on: ubuntu-22.04
+    steps:
+      - uses: actions/checkout@v3
+      - name: Build and publish to PyPI
+        uses: JRubics/poetry-publish@v1.16
+        with:
+          python_version: "3.11"
+          poetry_version: "==1.3.2"
+          ignore_dev_requirements: "yes"
+          pypi_token: ${{ secrets.PYPI_TOKEN }}


### PR DESCRIPTION
Create a new `release` workflow based on the [poetry-publish](https://github.com/marketplace/actions/publish-python-poetry-package) action that only runs of all other required workflows complete successfully on a release tag.

Also, upgrade the Python version on the `pre-commit` action to 3.11 for consistency, and ensure that formatting in all workflow files are consistent.