### PR TITLE
Create a `buildarr-dummy` plugin for testing the Buildarr plugin API

### DIFF
--- a/buildarr/manager/__init__.py
+++ b/buildarr/manager/__init__.py
@@ -22,13 +22,9 @@ Buildarr manager interface functions.
 from __future__ import annotations
 
 from pathlib import Path
-from typing import Generic, TypeVar
+from typing import Generic
 
-from ..config import ConfigPlugin
-from ..secrets import SecretsPlugin
-
-Config = TypeVar("Config", bound=ConfigPlugin)
-Secrets = TypeVar("Secrets", bound=SecretsPlugin)
+from ..plugins import Config, Secrets
 
 
 class ManagerPlugin(Generic[Config, Secrets]):
@@ -49,8 +45,8 @@ class ManagerPlugin(Generic[Config, Secrets]):
 
     ```python
     from buildarr.manager import ManagerPlugin
-    from buildarr_example.config import ExampleConfig
-    from buildarr_example.secrets import ExampleSecrets
+    from .config import ExampleConfig
+    from .secrets import ExampleSecrets
 
     class ExampleManager(ManagerPlugin[ExampleConfig, ExampleSecrets]):
         pass

--- a/buildarr/plugins/__init__.py
+++ b/buildarr/plugins/__init__.py
@@ -21,7 +21,7 @@ Buildarr plugin specification.
 
 from __future__ import annotations
 
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, TypeVar
 
 if TYPE_CHECKING:
     from typing import Type
@@ -93,3 +93,18 @@ class Plugin:
     config: Type[ConfigPlugin]
     manager: Type[ManagerPlugin]
     secrets: Type[SecretsPlugin]
+
+
+Config = TypeVar("Config", bound="ConfigPlugin")
+"""
+Type hint for a configuration module of a plugin.
+
+When creating plugins, substitute `Config` for the implementing config plugin type.
+"""
+
+Secrets = TypeVar("Secrets", bound="SecretsPlugin")
+"""
+Type hint for a secrets module of a plugin.
+
+When creating plugins, substitute `Secrets` for the implementing secrets plugin type.
+"""

--- a/buildarr/plugins/dummy/api.py
+++ b/buildarr/plugins/dummy/api.py
@@ -1,0 +1,190 @@
+# -*- coding: utf-8 -*-
+
+# Copyright (C) 2023 Callum Dickinson
+#
+# Buildarr is free software: you can redistribute it and/or modify it under the terms of the
+# GNU General Public License as published by the Free Software Foundation,
+# either version 3 of the License, or (at your option) any later version.
+#
+# Buildarr is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY;
+# without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+# See the GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License along with Buildarr.
+# If not, see <https://www.gnu.org/licenses/>.
+
+
+"""
+Dummy plugin API functions.
+"""
+
+
+from __future__ import annotations
+
+import re
+
+from typing import TYPE_CHECKING
+
+import json5  # type: ignore[import]
+import requests
+
+from buildarr.logging import plugin_logger
+
+from .exceptions import DummyAPIError
+
+if TYPE_CHECKING:
+    from typing import Any, Dict, Optional
+
+    from .secrets import DummySecrets
+
+
+INITIALIZE_JS_RES_PATTERN = re.compile(r"(?s)^window\.Dummy = ({.*});$")
+
+
+def get_initialize_js(host_url: str, api_key: Optional[str] = None) -> Dict[str, Any]:
+    """
+    Get the Dummy session initialisation metadata, including the API key.
+
+    Args:
+        host_url (str): Dummy instance URL.
+        api_key (str): Dummy instance API key, if required. Defaults to `None`.
+
+    Returns:
+        Session initialisation metadata
+    """
+
+    url = f"{host_url}/initialize.js"
+    plugin_logger.debug("GET %s", url)
+    res = requests.get(
+        url,
+        headers={"X-Api-Key": api_key} if api_key else None,
+    )
+    res_match = re.match(INITIALIZE_JS_RES_PATTERN, res.text)
+    assert res_match
+    res_json = json5.loads(res_match.group(1))
+    plugin_logger.debug("GET %s -> status_code=%i res=%s", url, res.status_code, repr(res_json))
+    return res_json
+
+
+def api_get(secrets: DummySecrets, api_url: str) -> Any:
+    """
+    Send a `GET` request to a Dummy instance.
+
+    Args:
+        secrets (DummySecrets): Dummy secrets metadata
+        api_url (str): Dummy API command
+
+    Returns:
+        Response object
+    """
+
+    url = f"{secrets.host_url}/{api_url.lstrip('/')}"
+    plugin_logger.debug("GET %s", url)
+    res = requests.get(url, headers={"X-Api-Key": secrets.api_key.get_secret_value()})
+    res_json = res.json()
+    plugin_logger.debug("GET %s -> status_code=%i res=%s", url, res.status_code, repr(res_json))
+    if res.status_code != 200:
+        api_error(method="GET", url=url, response=res)
+    return res_json
+
+
+def api_post(secrets: DummySecrets, api_url: str, req: Any) -> Any:
+    """
+    Send a `POST` request to a Dummy instance.
+
+    Args:
+        secrets (DummySecrets): Dummy secrets metadata
+        api_url (str): Dummy API command
+        req (Any): Request (JSON-serialisable)
+
+    Returns:
+        Response object
+    """
+
+    url = f"{secrets.host_url}/{api_url.lstrip('/')}"
+    plugin_logger.debug("POST %s <- req=%s", url, repr(req))
+    res = requests.post(
+        url,
+        headers={"X-Api-Key": secrets.api_key.get_secret_value()},
+        json=req,
+    )
+    res_json = res.json()
+    plugin_logger.debug("POST %s -> status_code=%i res=%s", url, res.status_code, repr(res_json))
+    if res.status_code != 201:
+        api_error(method="POST", url=url, response=res)
+    return res_json
+
+
+def api_put(secrets: DummySecrets, api_url: str, req: Any) -> Any:
+    """
+    Send a `PUT` request to a Dummy instance.
+
+    Args:
+        secrets (DummySecrets): Dummy secrets metadata
+        api_url (str): Dummy API command
+        req (Any): Request (JSON-serialisable)
+
+    Returns:
+        Response object
+    """
+
+    url = f"{secrets.host_url}/{api_url.lstrip('/')}"
+    plugin_logger.debug("PUT %s <- req=%s", url, repr(req))
+    res = requests.put(
+        url,
+        headers={"X-Api-Key": secrets.api_key.get_secret_value()},
+        json=req,
+    )
+    res_json = res.json()
+    plugin_logger.debug("PUT %s -> status_code=%i res=%s", url, res.status_code, repr(res_json))
+    if res.status_code != 202:
+        api_error(method="PUT", url=url, response=res)
+    return res_json
+
+
+def api_delete(secrets: DummySecrets, api_url: str) -> None:
+    """
+    Send a `DELETE` request to a Dummy instance.
+
+    Args:
+        secrets (DummySecrets): Dummy secrets metadata
+        api_url (str): Dummy API command
+    """
+
+    url = f"{secrets.host_url}/{api_url.lstrip('/')}"
+    plugin_logger.debug("DELETE %s", url)
+    res = requests.delete(url, headers={"X-Api-Key": secrets.api_key.get_secret_value()})
+    plugin_logger.debug("DELETE %s -> status_code=%i", url, res.status_code)
+    if res.status_code != 200:
+        api_error(method="DELETE", url=url, response=res, parse_response=False)
+
+
+def api_error(
+    method: str,
+    url: str,
+    response: requests.Response,
+    parse_response: bool = True,
+) -> None:
+    """
+    Process an error response from the Dummy API.
+
+    Args:
+        method (str): HTTP method.
+        url (str): API command URL.
+        response (requests.Response): Response metadata.
+        parse_response (bool, optional): Parse response error JSON. Defaults to True.
+
+    Raises:
+        Dummy API exception
+    """
+
+    error_message = (
+        f"Unexpected response with status code {response.status_code} from from '{method} {url}'"
+    )
+    if parse_response:
+        res_json = response.json()
+        try:
+            error_message += f": {res_json['message']}\n{res_json['description']}"
+        except KeyError:
+            error_message += f": {res_json}"
+    raise DummyAPIError(error_message, response=response)

--- a/buildarr/plugins/dummy/cli.py
+++ b/buildarr/plugins/dummy/cli.py
@@ -1,0 +1,93 @@
+# -*- coding: utf-8 -*-
+
+# Copyright (C) 2023 Callum Dickinson
+#
+# Buildarr is free software: you can redistribute it and/or modify it under the terms of the
+# GNU General Public License as published by the Free Software Foundation,
+# either version 3 of the License, or (at your option) any later version.
+#
+# Buildarr is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY;
+# without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+# See the GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License along with Buildarr.
+# If not, see <https://www.gnu.org/licenses/>.
+
+
+"""
+Dummy plugin CLI commands.
+"""
+
+
+import functools
+
+from getpass import getpass
+from urllib.parse import urlparse
+
+import click
+import click_params  # type: ignore[import]
+
+from .config import DummyConfig
+from .manager import DummyManager
+from .secrets import DummySecrets
+
+
+@click.group(help="Dummy instance ad-hoc commands.")
+def dummy():
+    """
+    Dummy instance ad-hoc commands.
+    """
+
+    pass
+
+
+@dummy.command(
+    help=(
+        "Dump configuration from a remote Dummy instance.\n\n"
+        "The configuration is dumped to standard output in Buildarr-compatible YAML format."
+    ),
+)
+@click.argument("url", type=click_params.URL)
+@click.option(
+    "-k",
+    "--api-key",
+    "api_key",
+    metavar="API-KEY",
+    default=functools.partial(getpass, "Dummy instance API key: "),
+    help="API key of the Dummy instance. The user will be prompted if undefined.",
+)
+def dump_config(url: str, api_key: str) -> int:
+    """
+    Dump configuration from a remote Dummy instance.
+    The configuration is dumped to standard output in Buildarr-compatible YAML format.
+    """
+
+    # Parse the specified instance URL to get its constituent components.
+    url_obj = urlparse(url)
+    protocol = url_obj.scheme
+    hostname_port = url_obj.netloc.split(":", 1)
+    hostname = hostname_port[0]
+    port = (
+        int(hostname_port[1]) if len(hostname_port) == 2 else (443 if protocol == "https" else 80)
+    )
+
+    # Create a default configuration object for the Dummy instance,
+    # storing the connection information.
+    # TODO: Unnecessary as the secrets already contains this information, so remove this step.
+    dummy_config = DummyConfig(hostname=hostname, port=port, protocol=protocol)
+
+    # Generate the secrets metadata for the Dummy instance.
+    dummy_secrets = DummySecrets(
+        hostname=hostname,
+        port=port,
+        protocol=protocol,
+        api_key=api_key,
+    )
+
+    # Pull the remote Dummy instance configuration, and create the configuration object.
+    dummy_config = DummyManager().from_remote(config=dummy_config, secrets=dummy_secrets)
+
+    # Serialise the Dummy instance configuration into YAML, and write it to standard output.
+    click.echo(dummy_config.yaml())
+
+    return 0

--- a/buildarr/plugins/dummy/config/__init__.py
+++ b/buildarr/plugins/dummy/config/__init__.py
@@ -1,0 +1,248 @@
+# -*- coding: utf-8 -*-
+
+# Copyright (C) 2023 Callum Dickinson
+#
+# Buildarr is free software: you can redistribute it and/or modify it under the terms of the
+# GNU General Public License as published by the Free Software Foundation,
+# either version 3 of the License, or (at your option) any later version.
+#
+# Buildarr is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY;
+# without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+# See the GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License along with Buildarr.
+# If not, see <https://www.gnu.org/licenses/>.
+
+
+"""
+Dummy plugin configuration.
+"""
+
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import TYPE_CHECKING, Dict, Optional
+
+from typing_extensions import Self
+
+from buildarr.config import ConfigPlugin, NonEmptyStr, Port
+
+from ..api import get_initialize_js
+from ..secrets import DummySecrets
+from ..util import DummyApiKey, DummyProtocol
+from .settings import DummySettingsConfig
+
+# Allow Mypy to properly resolve secrets type declarations in configuration classes.
+if TYPE_CHECKING:
+
+    class _DummyInstanceConfig(ConfigPlugin[DummySecrets]):
+        ...
+
+else:
+
+    class _DummyInstanceConfig(ConfigPlugin):
+        ...
+
+
+class DummyInstanceConfig(_DummyInstanceConfig):
+    """
+    By default, Buildarr will look for a single instance at `http://dummy:5000`.
+    Most configurations are different, and to accommodate those, you can configure
+    how Buildarr connects to individual Dummy instances.
+
+    Configuration of a single Dummy instance:
+
+    ```yaml
+    dummy:
+      hostname: "localhost"
+      port: 5000
+      protocol: "http"
+      settings:
+        ...
+    ```
+
+    Configuration of multiple instances:
+
+    ```yaml
+    dummy:
+      # Configuration and settings common to all instances.
+      hostname: "localhost"
+      protocol: "http"
+      settings:
+        ...
+      instances:
+        # Dummy instance 1-specific configuration.
+        dummy1:
+          port: 5000
+          settings:
+            ...
+        # Dummy instance 2-specific configuration.
+        dummy:
+          port: 5001
+          api_key: "..." # Explicitly define API key
+          settings:
+            ...
+    ```
+    """
+
+    hostname: NonEmptyStr = "dummy"  # type: ignore[assignment]
+    """
+    Hostname of the Dummy instance to connect to.
+
+    When defining a single instance using the global `dummy` configuration block,
+    the default hostname is `dummy`.
+
+    When using multiple instance-specific configurations, the default hostname
+    is the name given to the instance in the `instances` attribute.
+
+    ```yaml
+    dummy:
+      instances:
+        dummy1: # <--- This becomes the default hostname
+          ...
+    ```
+    """
+
+    port: Port = 5000  # type: ignore[assignment]
+    """
+    Port number of the Dummy instance to connect to.
+    """
+
+    protocol: DummyProtocol = "http"  # type: ignore[assignment]
+    """
+    Communication protocol to use to connect to Dummy.
+
+    Values:
+
+    * `http`
+    """
+
+    api_key: Optional[DummyApiKey] = None
+    """
+    API key to use to authenticate with the Dummy instance.
+
+    If undefined or set to `None`, automatically retrieve the API key.
+    This can only be done on Dummy instances with authentication disabled.
+    """
+
+    version: Optional[str] = None
+    """
+    The expected version of the Dummy instance.
+    If undefined or set to `None`, the version is auto-detected.
+
+    At the moment this attribute is unused, and there is likely no need to explicitly set it.
+    """
+
+    settings: DummySettingsConfig = DummySettingsConfig()
+    """
+    Dummy settings.
+    Configuration options for Dummy itself are set within this structure.
+    """
+
+    @property
+    def uses_trash_metadata(self) -> bool:
+        """
+        A flag determining whether or not this instance configuration uses TRaSH-Guides metadata.
+
+        Returns:
+            `True` if TRaSH-Guides metadata is used, otherwise `False`
+        """
+        return self.settings.uses_trash_metadata
+
+    def render_trash_metadata(self, trash_metadata_dir: Path) -> Self:
+        """
+        Read TRaSH-Guides metadata, and return a configuration object with all templates rendered.
+
+        Args:
+            trash_metadata_dir (Path): TRaSH-Guides metadata directory.
+
+        Returns:
+            Rendered configuration object
+        """
+        copy = self.copy(deep=True)
+        copy._render_trash_metadata(trash_metadata_dir)
+        return copy
+
+    def _render_trash_metadata(self, trash_metadata_dir: Path) -> None:
+        """
+        Render configuration attributes obtained from TRaSH-Guides, in-place.
+
+        Args:
+            trash_metadata_dir (Path): TRaSH-Guides metadata directory.
+        """
+        if self.settings.uses_trash_metadata:
+            self.settings._render_trash_metadata(trash_metadata_dir)
+
+    @classmethod
+    def from_remote(cls, secrets: DummySecrets) -> Self:
+        """
+        Read configuration from a remote instance and return it as a configuration object.
+
+        Args:
+            secrets (DummySecrets): Instance host and secrets information
+
+        Returns:
+            Configuration object for remote instance
+        """
+        return cls(
+            hostname=secrets.hostname,
+            port=secrets.port,
+            protocol=secrets.protocol,
+            api_key=secrets.api_key,
+            version=get_initialize_js(
+                host_url=secrets.host_url,
+                api_key=secrets.api_key.get_secret_value(),
+            )["version"],
+            settings=DummySettingsConfig.from_remote(secrets),
+        )
+
+
+class DummyConfig(DummyInstanceConfig):
+    """
+    Dummy plugin global configuration class.
+
+    Subclasses the instance-specific configuration to allow
+    attributes common to all instances to be defined in one place.
+    """
+
+    instances: Dict[str, DummyInstanceConfig] = {}
+    """
+    Instance-specific Dummy configuration.
+
+    Can only be defined on the global `dummy` configuration block.
+
+    Globally specified configuration values apply to all instances.
+    Configuration values specified on an instance-level take precedence at runtime.
+    """
+
+    @property
+    def uses_trash_metadata(self) -> bool:
+        """
+        A flag determining whether or not this configuration uses TRaSH-Guides metadata.
+
+        Returns:
+            `True` if TRaSH-Guides metadata is used, otherwise `False`
+        """
+        for instance in self.instances.values():
+            if instance.uses_trash_metadata:
+                return True
+        return super().uses_trash_metadata
+
+    def render_trash_metadata(self, trash_metadata_dir: Path) -> Self:
+        """
+        Read TRaSH-Guides metadata, and return a configuration object with all templates rendered.
+
+        Args:
+            trash_metadata_dir (Path): TRaSH-Guides metadata directory.
+
+        Returns:
+            Rendered configuration object
+        """
+        copy = self.copy(deep=True)
+        for instance in copy.instances.values():
+            if instance.uses_trash_metadata:
+                instance._render_trash_metadata(trash_metadata_dir)
+        if self.uses_trash_metadata:
+            copy._render_trash_metadata(trash_metadata_dir)
+        return copy

--- a/buildarr/plugins/dummy/config/settings.py
+++ b/buildarr/plugins/dummy/config/settings.py
@@ -1,0 +1,182 @@
+# -*- coding: utf-8 -*-
+
+# Copyright (C) 2023 Callum Dickinson
+#
+# Buildarr is free software: you can redistribute it and/or modify it under the terms of the
+# GNU General Public License as published by the Free Software Foundation,
+# either version 3 of the License, or (at your option) any later version.
+#
+# Buildarr is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY;
+# without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+# See the GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License along with Buildarr.
+# If not, see <https://www.gnu.org/licenses/>.
+
+
+"""
+Dummy plugin settings configuration.
+"""
+
+
+from __future__ import annotations
+
+import json
+
+from pathlib import Path
+from typing import Any, List, Mapping, Optional, Union, cast
+
+from typing_extensions import Self
+
+from buildarr.config import RemoteMapEntry, TrashID
+from buildarr.config.exceptions import ConfigTrashIDNotFoundError
+
+from ..api import api_get, api_post
+from ..secrets import DummySecrets
+from .types import DummyConfigBase
+
+
+class DummySettingsConfig(DummyConfigBase):
+    """
+    Dummy settings configuration.
+
+    Specify any of the following attributes to ensure the attribute
+    on the remote Dummy instance is set accordingly.
+
+    ```yaml
+    dummy:
+      settings:
+        trash_value: 5
+    ```
+
+    Specify `trash_id` to get a value from TRaSH-Guides metadata and set it to `trash_value`.
+
+    ```yaml
+    dummy:
+      settings:
+        trash_id: "387e6278d8e06083d813358762e0ac63" # anime
+    ```
+    """
+
+    trash_id: Optional[TrashID] = None  # type: ignore[assignment]
+    """
+    TRaSH-Guides Sonarr quality definition profile ID to use when filling out `trash_value`.
+    """
+
+    trash_value: Union[float, None] = None
+    """
+    Value retrieved from the TRaSH-Guides repository.
+
+    If this value is explicitly specified in the configuration, it does not get overwritten.
+    """
+
+    _remote_map: List[RemoteMapEntry] = [
+        (
+            "trash_value",  # Buildarr config attribute name.
+            "trashValue",  # Dummy instance API attribute name.
+            {},  # Local/remote map conversion function parameters.
+        ),
+    ]
+    """
+    A list of remote map entries containing metadata for how to convert
+    between local and remote Dummy instance configuration values.
+
+    For more information on how to create this structure,
+    see the documentation for the following methods in `buildarr/config/__init__.py`:
+
+    * `ConfigBase.get_local_attrs`
+    * `ConfigBase.get_create_remote_attrs`
+    * `ConfigBase.get_update_remote_attrs`
+    """
+
+    @property
+    def uses_trash_metadata(self) -> bool:
+        """
+        A flag determining whether or not this instance configuration uses TRaSH-Guides metadata.
+
+        Returns:
+            `True` if TRaSH-Guides metadata is used, otherwise `False`
+        """
+        return bool(self.trash_id)
+
+    def _render_trash_metadata(self, sonarr_metadata_dir: Path) -> None:
+        """
+        Render configuration attributes obtained from TRaSH-Guides, in-place.
+
+        Set `trash_value` to the minimum data rate value for the
+        `Bluray-1080p` quality definition in the profile.
+
+        Args:
+            trash_metadata_dir (Path): TRaSH-Guides metadata directory.
+        """
+        if not self.trash_id:
+            return
+        for quality_file in (
+            sonarr_metadata_dir / "docs" / "json" / "sonarr" / "quality-size"
+        ).iterdir():
+            with quality_file.open() as f:
+                quality_json: Mapping[str, Any] = json.load(f)
+                if cast(str, quality_json["trash_id"]).lower() == self.trash_id:
+                    for definition_json in quality_json["qualities"]:
+                        if definition_json["quality"] == "Bluray-1080p":
+                            self.trash_value = cast(float, definition_json["min"])
+                            break
+                    else:
+                        raise ValueError(
+                            "Quality definition 'Bluray-1080p' not found in TRaSH-Guides profile",
+                        )
+                    break
+        else:
+            raise ConfigTrashIDNotFoundError(
+                f"Unable to find Sonarr quality definition file with trash ID '{self.trash_id}'",
+            )
+
+    @classmethod
+    def from_remote(cls, secrets: DummySecrets) -> Self:
+        """
+        Read configuration from a remote instance and return it as a configuration object.
+
+        Args:
+            secrets (DummySecrets): Instance host and secrets information
+
+        Returns:
+            Configuration object for remote instance
+        """
+        return cls(
+            trash_id=None,
+            **cls.get_local_attrs(
+                remote_map=cls._remote_map,
+                remote_attrs=api_get(secrets, "/api/v1/settings"),
+            ),
+        )
+
+    def update_remote(
+        self,
+        tree: str,
+        secrets: DummySecrets,
+        remote: Self,
+        check_unmanaged: bool = False,
+    ) -> bool:
+        """
+        Compare this configuration to a remote instance's, and update the remote to match.
+
+        Args:
+            tree (str): Configuration tree represented as a string. Mainly used in logging.
+            secrets (DummySecrets): Remote instance host and secrets information.
+            remote (Self): Remote instance configuration for the current section.
+            check_unmanaged (bool, optional): Set unmanaged fields to defaults (default `False`).
+
+        Returns:
+            `True` if the remote configuration changed, otherwise `False`
+        """
+        changed, remote_attrs = self.get_update_remote_attrs(
+            tree=tree,
+            remote=remote,
+            remote_map=self._remote_map,
+            check_unmanaged=check_unmanaged,
+            set_unchanged=True,
+        )
+        if changed:
+            api_post(secrets, "/api/v1/settings", remote_attrs)
+            return True
+        return False

--- a/buildarr/plugins/dummy/config/types.py
+++ b/buildarr/plugins/dummy/config/types.py
@@ -1,0 +1,40 @@
+# -*- coding: utf-8 -*-
+
+# Copyright (C) 2023 Callum Dickinson
+#
+# Buildarr is free software: you can redistribute it and/or modify it under the terms of the
+# GNU General Public License as published by the Free Software Foundation,
+# either version 3 of the License, or (at your option) any later version.
+#
+# Buildarr is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY;
+# without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+# See the GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License along with Buildarr.
+# If not, see <https://www.gnu.org/licenses/>.
+
+
+"""
+Dummy plugin configuration utility classes and functions.
+"""
+
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+from buildarr.config import ConfigBase
+
+# Define the base class for Dummy configuration classes.
+# Subclassing this conditionally-created class allows Mypy to
+# properly resolve secrets type declarations.
+if TYPE_CHECKING:
+    from ..secrets import DummySecrets
+
+    class DummyConfigBase(ConfigBase[DummySecrets]):
+        ...
+
+else:
+
+    class DummyConfigBase(ConfigBase):
+        ...

--- a/buildarr/plugins/dummy/exceptions.py
+++ b/buildarr/plugins/dummy/exceptions.py
@@ -1,0 +1,47 @@
+# -*- coding: utf-8 -*-
+
+# Copyright (C) 2023 Callum Dickinson
+#
+# Buildarr is free software: you can redistribute it and/or modify it under the terms of the
+# GNU General Public License as published by the Free Software Foundation,
+# either version 3 of the License, or (at your option) any later version.
+#
+# Buildarr is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY;
+# without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+# See the GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License along with Buildarr.
+# If not, see <https://www.gnu.org/licenses/>.
+
+
+"""
+Dummy plugin exception classes.
+"""
+
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+from buildarr.exceptions import BuildarrError
+
+if TYPE_CHECKING:
+    from requests import Response
+
+
+class DummyError(BuildarrError):
+    """
+    Dummy plugin exception base class.
+    """
+
+    pass
+
+
+class DummyAPIError(DummyError):
+    """
+    Dummy API exception class.
+    """
+
+    def __init__(self, msg: str, response: Response) -> None:
+        self.response = response
+        super().__init__(msg)

--- a/buildarr/plugins/dummy/manager.py
+++ b/buildarr/plugins/dummy/manager.py
@@ -1,0 +1,31 @@
+# -*- coding: utf-8 -*-
+
+# Copyright (C) 2023 Callum Dickinson
+#
+# Buildarr is free software: you can redistribute it and/or modify it under the terms of the
+# GNU General Public License as published by the Free Software Foundation,
+# either version 3 of the License, or (at your option) any later version.
+#
+# Buildarr is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY;
+# without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+# See the GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License along with Buildarr.
+# If not, see <https://www.gnu.org/licenses/>.
+
+
+"""
+Dummy plugin manager class.
+"""
+
+
+from __future__ import annotations
+
+from buildarr.manager import ManagerPlugin
+
+from .config import DummyConfig
+from .secrets import DummySecrets
+
+
+class DummyManager(ManagerPlugin[DummyConfig, DummySecrets]):
+    pass

--- a/buildarr/plugins/dummy/plugin.py
+++ b/buildarr/plugins/dummy/plugin.py
@@ -1,0 +1,38 @@
+# -*- coding: utf-8 -*-
+
+# Copyright (C) 2023 Callum Dickinson
+#
+# Buildarr is free software: you can redistribute it and/or modify it under the terms of the
+# GNU General Public License as published by the Free Software Foundation,
+# either version 3 of the License, or (at your option) any later version.
+#
+# Buildarr is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY;
+# without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+# See the GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License along with Buildarr.
+# If not, see <https://www.gnu.org/licenses/>.
+
+
+"""
+Dummy plugin interface.
+"""
+
+
+from buildarr.plugins import Plugin
+
+from .cli import dummy
+from .config import DummyConfig
+from .manager import DummyManager
+from .secrets import DummySecrets
+
+
+class DummyPlugin(Plugin):
+    """
+    Dummy plugin class that Buildarr reads to process Dummy instances.
+    """
+
+    cli = dummy
+    config = DummyConfig
+    manager = DummyManager
+    secrets = DummySecrets

--- a/buildarr/plugins/dummy/secrets.py
+++ b/buildarr/plugins/dummy/secrets.py
@@ -1,0 +1,108 @@
+# -*- coding: utf-8 -*-
+
+# Copyright (C) 2023 Callum Dickinson
+#
+# Buildarr is free software: you can redistribute it and/or modify it under the terms of the
+# GNU General Public License as published by the Free Software Foundation,
+# either version 3 of the License, or (at your option) any later version.
+#
+# Buildarr is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY;
+# without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+# See the GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License along with Buildarr.
+# If not, see <https://www.gnu.org/licenses/>.
+
+
+"""
+Dummy plugin secrets file model.
+"""
+
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+from urllib.parse import urlparse
+
+from buildarr.config import NonEmptyStr, Port
+from buildarr.secrets import SecretsPlugin
+
+from .api import get_initialize_js
+from .util import DummyApiKey, DummyProtocol
+
+# Allow Mypy to properly resolve configuration type declarations in secrets classes.
+if TYPE_CHECKING:
+    from typing_extensions import Self
+
+    from .config import DummyConfig
+
+    class _DummySecrets(SecretsPlugin[DummyConfig]):
+        ...
+
+else:
+
+    class _DummySecrets(SecretsPlugin):
+        ...
+
+
+class DummySecrets(_DummySecrets):
+    """
+    Dummy API secrets.
+    """
+
+    hostname: NonEmptyStr
+    port: Port
+    protocol: DummyProtocol
+
+    api_key: DummyApiKey
+
+    @property
+    def host_url(self) -> str:
+        """
+        Full host URL for the Dummy instance.
+        """
+        return f"{self.protocol}://{self.hostname}:{self.port}"
+
+    @classmethod
+    def from_url(cls, host_url: str, api_key: str) -> Self:
+        """
+        Generate a secrets object from its constituent host URL and API key.
+
+        Args:
+            host_url (str): Full host URL of the instance
+            api_key (str): API key used to authenticate with the instance
+
+        Returns:
+            Secrets object
+        """
+        url_obj = urlparse(host_url)
+        hostname_port = url_obj.netloc.rsplit(":", 1)
+        hostname = hostname_port[0]
+        protocol = url_obj.scheme
+        port = (
+            int(hostname_port[1])
+            if len(hostname_port) > 1
+            else (443 if protocol == "https" else 80)
+        )
+        return cls(hostname=hostname, port=port, protocol=protocol, api_key=api_key)
+
+    @classmethod
+    def get(cls, config: DummyConfig) -> Self:
+        """
+        Generate a secrets object from the given instance configuration,
+        retrieving any necessary secrets in the process.
+
+        Args:
+            config (DummyConfig): Instance configuration
+
+        Returns:
+            Secrets object
+        """
+        return cls(
+            hostname=config.hostname,
+            port=config.port,
+            protocol=config.protocol,
+            api_key=(
+                config.api_key if config.api_key else get_initialize_js(config.host_url)["apiKey"]
+            ),
+        )

--- a/buildarr/plugins/dummy/server.py
+++ b/buildarr/plugins/dummy/server.py
@@ -1,0 +1,202 @@
+# -*- coding: utf-8 -*-
+
+# Copyright (C) 2023 Callum Dickinson
+#
+# Buildarr is free software: you can redistribute it and/or modify it under the terms of the
+# GNU General Public License as published by the Free Software Foundation,
+# either version 3 of the License, or (at your option) any later version.
+#
+# Buildarr is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY;
+# without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+# See the GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License along with Buildarr.
+# If not, see <https://www.gnu.org/licenses/>.
+
+
+"""
+Dummy server Flask application.
+
+This simulates an application that keeps state that can be modified via an API.
+
+To run this application, run the following command:
+
+```bash
+$ BUILDARR_DUMMY_API_KEY="1a2b3c4d5e" flask --app buildarr.plugins.dummy.server run
+```
+
+This file is not required when creating a new plugin.
+
+This is simply for convenience when testing, to give the Dummy plugin something
+to communicate with for testing purposes.
+"""
+
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING, Mapping, cast
+
+from flask import Flask, Response, jsonify, request
+from werkzeug.exceptions import Unauthorized
+
+from buildarr import __version__ as buildarr_version
+
+if TYPE_CHECKING:
+    from typing import Any, Dict, Tuple
+
+
+__all__ = ["app"]
+
+app = Flask("buildarr-dummy-server")
+
+app.config.from_prefixed_env(prefix="BUILDARR_DUMMY")
+if "API_ROOT" not in app.config:
+    app.config["API_ROOT"] = "/api/v1"
+
+_settings: Dict[str, Any] = {
+    "isUpdated": False,  # bool
+    "trashValue": None,  # Optional[float]
+}
+
+
+def check_api_key() -> None:
+    """
+    Check if a valid API key was supplied in the request headers.
+
+    If invalid or not specified when required, raise an error to make
+    Flask return a `401 Unauthorized` response.
+    """
+
+    if "API_KEY" not in app.config or not app.config["API_KEY"]:
+        return
+
+    if "X-Api-Key" not in request.headers:
+        raise Unauthorized(description="API key required but not provided")
+
+    if request.headers["X-Api-Key"] != app.config["API_KEY"]:
+        raise Unauthorized(description="Incorrect API key")
+
+
+@app.errorhandler(401)
+def unauthorized(error: Unauthorized) -> Tuple[Response, int]:
+    """
+    Handle a `401 Unauthorized` error.
+
+    Args:
+        error (Unauthorized): Unauthorized exception object
+
+    Returns:
+        Error responses
+    """
+
+    return (jsonify({"message": "Unauthorized", "description": error.description}), 401)
+
+
+@app.get("/initialize.js")
+def get_initialize_js() -> Tuple[str, int]:
+    """
+    Return the Dummy API initialisation JavaScript code.
+
+    ```bash
+    $ curl http://localhost:5000/initialize.js
+    window.Dummy = {
+    apiRoot: '/api/v1',
+    apiKey: '1a2b3c4d5e',
+    version: '0.1.0'
+    };
+    ```
+
+    Returns:
+        `initialize.js`
+    """
+
+    res = f"window.Dummy = {{\n  apiRoot: {repr(app.config['API_ROOT'])}"
+    if "API_KEY" in app.config and app.config["API_KEY"]:
+        res += f",\n  apiKey: {repr(app.config['API_KEY'])}"
+    res += f",\n  version: {repr(buildarr_version)}\n}};"
+
+    return (res, 200)
+
+
+@app.get(f"{app.config['API_ROOT']}/settings")
+def get_settings() -> Tuple[Response, int]:
+    """
+    Return the current Dummy server settings.
+
+    ```bash
+    $ curl -H "X-Api-Key: 1a2b3c4d5e" http://localhost:5000/api/v1/settings
+    {"isUpdated":false,"trashValue":null}
+    ```
+
+    Returns:
+        Current Dummy server settings
+    """
+
+    global _settings
+
+    check_api_key()
+
+    return (jsonify(_settings), 200)
+
+
+@app.route(f"{app.config['API_ROOT']}/settings", methods=["POST", "PUT"])
+def update_settings() -> Tuple[Response, int]:
+    """
+    Update the Dummy server settings, and return a copy of the old settings.
+    When a settings update is performed, `isUpdated` will be set to `True`.
+
+    Only updated configuration values need to be specified.
+
+    ```bash
+    $ curl -X PUT http://localhost:5000/api/v1/settings \
+           -H "X-Api-Key: 1a2b3c4d5e" \
+           -H "Content-Type: application/json" \
+           -d '{"trashValue":2.0}'
+    {"isUpdated":false,"trashValue":null}
+    ```
+
+    Subsequent requests to get the server settings will return updated values.
+
+    ```bash
+    $ curl -H "X-Api-Key: 1a2b3c4d5e" http://localhost:5000/api/v1/settings
+    {"isUpdated":true,"trashValue":2.0}
+    ```
+
+    Updated settings will be lost when the server shuts down.
+
+    Returns:
+        Old Dummy server settings
+    """
+
+    global _settings
+
+    check_api_key()
+
+    old_settings = _settings
+    _settings = merge_dicts(old_settings, cast(Mapping, request.json), {"isUpdated": True})
+    return (jsonify(old_settings), 201)
+
+
+def merge_dicts(*dicts: Mapping[Any, Any]) -> Dict[Any, Any]:
+    """
+    Recursively merge the specificed mappings into one dictionary structure.
+
+    If the same key exists at the same level in more than one mapping,
+    the last referenced one takes prcedence.
+
+    Returns:
+        Merged dictionary
+    """
+
+    merged_dict: Dict[Any, Any] = {}
+
+    for d in dicts:
+        for key, value in d.items():
+            if key in merged_dict and isinstance(merged_dict[key], Mapping):
+                merged_dict[key] = merge_dicts(merged_dict[key], value)
+            elif isinstance(value, Mapping):
+                merged_dict[key] = merge_dicts(value)
+            else:
+                merged_dict[key] = value
+
+    return merged_dict

--- a/buildarr/plugins/dummy/util.py
+++ b/buildarr/plugins/dummy/util.py
@@ -1,0 +1,46 @@
+# -*- coding: utf-8 -*-
+
+# Copyright (C) 2023 Callum Dickinson
+#
+# Buildarr is free software: you can redistribute it and/or modify it under the terms of the
+# GNU General Public License as published by the Free Software Foundation,
+# either version 3 of the License, or (at your option) any later version.
+#
+# Buildarr is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY;
+# without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+# See the GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License along with Buildarr.
+# If not, see <https://www.gnu.org/licenses/>.
+
+
+"""
+Dummy plugin utility objects and functions.
+"""
+
+
+from typing import Literal
+
+from buildarr.config import Password
+
+DummyApiKey = Password
+"""
+Constrained string type for a Dummy instance API key.
+
+The type `Password` allows anything as long as it is not an empty string, but is a subclass
+of type `pydantic.SecretStr`, allowing Buildarr to hide the value in any logging.
+
+A more complex type for API key might look something like this:
+
+```python
+from pydantic import Field, SecretStr
+from typing_extensions import Annotated
+
+DummyApiKey = Annotated[SecretStr, Field(min_length=32, max_length=32)]
+```
+"""
+
+DummyProtocol = Literal["http"]
+"""
+Allowed protocols for communicating with a Dummy instance.
+"""

--- a/buildarr/secrets.py
+++ b/buildarr/secrets.py
@@ -22,17 +22,18 @@ Buildarr secrets file handling interface.
 from __future__ import annotations
 
 from pathlib import Path
-from typing import TYPE_CHECKING, Dict, Type
+from typing import TYPE_CHECKING, Dict, Generic, Type
 
 from pydantic import BaseModel, ConstrainedStr, SecretStr, create_model
 
 from .logging import logger
+from .plugins import Config
 from .state import plugins
 
 if TYPE_CHECKING:
     from typing import Set
 
-    from .config import ConfigPlugin
+    from typing_extensions import Self
 
 
 class NonEmptyStr(ConstrainedStr):
@@ -57,7 +58,7 @@ class SecretsBase(BaseModel):
     pass
 
 
-class SecretsPlugin(SecretsBase):
+class SecretsPlugin(SecretsBase, Generic[Config]):
     """
     Buildarr plugin secrets metadata object base class.
 
@@ -86,7 +87,7 @@ class SecretsPlugin(SecretsBase):
     """
 
     @classmethod
-    def get(cls, config: ConfigPlugin) -> SecretsPlugin:
+    def get(cls, config: Config) -> Self:
         """
         Generate the secrets metadata for the given instance-specific configuration.
 

--- a/poetry.lock
+++ b/poetry.lock
@@ -270,6 +270,29 @@ pycodestyle = ">=2.10.0,<2.11.0"
 pyflakes = ">=3.0.0,<3.1.0"
 
 [[package]]
+name = "flask"
+version = "2.2.3"
+description = "A simple framework for building complex web applications."
+category = "dev"
+optional = false
+python-versions = ">=3.7"
+files = [
+    {file = "Flask-2.2.3-py3-none-any.whl", hash = "sha256:c0bec9477df1cb867e5a67c9e1ab758de9cb4a3e52dd70681f59fa40a62b3f2d"},
+    {file = "Flask-2.2.3.tar.gz", hash = "sha256:7eb373984bf1c770023fce9db164ed0c3353cd0b53f130f4693da0ca756a2e6d"},
+]
+
+[package.dependencies]
+click = ">=8.0"
+importlib-metadata = {version = ">=3.6.0", markers = "python_version < \"3.10\""}
+itsdangerous = ">=2.0"
+Jinja2 = ">=3.0"
+Werkzeug = ">=2.2.2"
+
+[package.extras]
+async = ["asgiref (>=3.2)"]
+dotenv = ["python-dotenv"]
+
+[[package]]
 name = "ghp-import"
 version = "2.1.0"
 description = "Copy your docs directly to the gh-pages branch."
@@ -354,6 +377,18 @@ colors = ["colorama (>=0.4.3)"]
 pipfile-deprecated-finder = ["pip-shims (>=0.5.2)", "pipreqs", "requirementslib"]
 plugins = ["setuptools"]
 requirements-deprecated-finder = ["pip-api", "pipreqs"]
+
+[[package]]
+name = "itsdangerous"
+version = "2.1.2"
+description = "Safely pass data to untrusted environments and back."
+category = "dev"
+optional = false
+python-versions = ">=3.7"
+files = [
+    {file = "itsdangerous-2.1.2-py3-none-any.whl", hash = "sha256:2c2349112351b88699d8d4b6b075022c0808887cb7ad10069318a8b0bc88db44"},
+    {file = "itsdangerous-2.1.2.tar.gz", hash = "sha256:5dbbc68b317e5e42f327f9021763545dc3fc3bfe22e6deb96aaf1fc38874156a"},
+]
 
 [[package]]
 name = "jinja2"
@@ -1063,6 +1098,24 @@ files = [
 watchmedo = ["PyYAML (>=3.10)"]
 
 [[package]]
+name = "werkzeug"
+version = "2.2.3"
+description = "The comprehensive WSGI web application library."
+category = "dev"
+optional = false
+python-versions = ">=3.7"
+files = [
+    {file = "Werkzeug-2.2.3-py3-none-any.whl", hash = "sha256:56433961bc1f12533306c624f3be5e744389ac61d722175d543e1751285da612"},
+    {file = "Werkzeug-2.2.3.tar.gz", hash = "sha256:2e1ccc9417d4da358b9de6f174e3ac094391ea1d4fbef2d667865d819dfd0afe"},
+]
+
+[package.dependencies]
+MarkupSafe = ">=2.1.1"
+
+[package.extras]
+watchdog = ["watchdog"]
+
+[[package]]
 name = "zipp"
 version = "3.13.0"
 description = "Backport of pathlib-compatible object wrapper for zip files"
@@ -1081,4 +1134,4 @@ testing = ["flake8 (<5)", "func-timeout", "jaraco.functools", "jaraco.itertools"
 [metadata]
 lock-version = "2.0"
 python-versions = "^3.8.1" # 3.8.1 specifically required by flake8 6.0.0.
-content-hash = "f22b07276f41351368c2616aa2849dc14a1216d4db1d3a9c50a781418de5ee8f"
+content-hash = "7f7694acc9bcd1bac15e7d7f4c34cb0d2114f74fba8b98451d12eb964c63bf4c"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -17,6 +17,7 @@ packages = [{include = "buildarr"}]
 buildarr = "buildarr.cli.main:main"
 
 [tool.poetry.plugins."buildarr.plugins"]
+"dummy" = "buildarr.plugins.dummy.plugin:DummyPlugin"
 "sonarr" = "buildarr.plugins.sonarr.plugin:SonarrPlugin"
 
 [tool.poetry.dependencies]
@@ -41,6 +42,8 @@ types-pyyaml = "6.0.12.5"
 types-requests = "2.28.11.12"
 mkdocs = "1.4.2"
 mkdocstrings = {extras = ["python"], version = "0.20.0"}
+flask = "2.2.3"
+werkzeug = "2.2.3"
 
 [tool.black]
 line_length = 100


### PR DESCRIPTION
Creates a new vendored plugin at `buildarr.plugins.dummy`, the Dummy plugin.

Unlike the Sonarr plugin, this one will not be separated into a new branch.

The Dummy plugin is meant to be both a reference for developing new plugins (with documentation for everything that is defined so plugin developers can more easily understand what is happening), and a functioning plugin with which Buildarr and its plugin API can be tested, both manually and in the [planned unit tests](https://github.com/buildarr/buildarr/issues/3).

The Dummy plugin is not loaded by default, as it is meant to be used for testing only, but can be used by setting the `BUILDARR_TESTING` environment variable to `true` (or some other truthy value), and defining a `dummy` configuration block in `buildarr.yml`:

```yaml
dummy:
  hostname: "localhost"
  port: 5000
  protocol: "http"
  settings:
    # Define `trash_value` from TRaSH-Guides...
    trash_id: "387e6278d8e06083d813358762e0ac63"
    # ...or define `trash_value` as an `int` or `float` manually.
    # trash_value: 5.0
```

At this time, the only supported `settings` attributes are `trash_id` and `trash_value`, but these will be expanded to enable testing of planned new Buildarr features.

The plugin also includes a Flask server at `buildarr.plugins.dummy.server`, to give the Dummy plugin a server to connect with:
```
$ BUILDARR_DUMMY_API_KEY="1a2b3c4d5e" flask --app buildarr.plugins.dummy.server run
 * Serving Flask app 'buildarr.plugins.dummy.server'
 * Debug mode: off
WARNING: This is a development server. Do not use it in a production deployment. Use a production WSGI server instead.
 * Running on http://127.0.0.1:5000
```

Running Buildarr against the Dummy server with the above configuration results in the following output:
```
$ BUILDARR_TESTING="true" buildarr run
2023-02-18 18:17:58,139 buildarr:49108 buildarr.main [INFO] Buildarr version 0.1.0 (log level: INFO)
2023-02-18 18:17:58,140 buildarr:49108 buildarr.main [INFO] Loading configuration file '/config/buildarr.yml'
2023-02-18 18:17:58,146 buildarr:49108 buildarr.main [INFO] Finished loading configuration file
2023-02-18 18:17:58,153 buildarr:49108 buildarr.main [INFO] Plugins loaded: dummy, sonarr
2023-02-18 18:17:58,153 buildarr:49108 buildarr.main [INFO] Using plugins: dummy
2023-02-18 18:17:58,155 buildarr:49108 buildarr.main [INFO] Loading secrets file from 'secrets.json'
2023-02-18 18:17:58,157 buildarr:49108 buildarr.main [INFO] Finished loading secrets file
2023-02-18 18:17:58,158 buildarr:49108 buildarr.plugins.dummy default [INFO] Checking and fetching secrets
2023-02-18 18:17:58,158 buildarr:49108 buildarr.plugins.dummy default [INFO] Finished checking and fetching secrets
2023-02-18 18:17:58,158 buildarr:49108 buildarr.main [INFO] Saving updated secrets file to 'secrets.json'
2023-02-18 18:17:58,160 buildarr:49108 buildarr.main [INFO] Finished saving updated secrets file
2023-02-18 18:18:05,315 buildarr:49108 buildarr.plugins.dummy default [INFO] Rendering TRaSH-Guides metadata
2023-02-18 18:18:05,317 buildarr:49108 buildarr.plugins.dummy default [INFO] Finished rendering TRaSH-Guides metadata
2023-02-18 18:18:05,317 buildarr:49108 buildarr.plugins.dummy default [INFO] Getting remote configuration
2023-02-18 18:18:09,400 buildarr:49108 buildarr.plugins.dummy default [INFO] Finished getting remote configuration
2023-02-18 18:18:09,401 buildarr:49108 buildarr.plugins.dummy default [INFO] Updating remote configuration
2023-02-18 18:18:09,401 buildarr:49108 buildarr.plugins.dummy default [INFO] dummy.settings.trash_value: None -> 5
2023-02-18 18:18:11,427 buildarr:49108 buildarr.plugins.dummy default [INFO] Remote configuration successfully updated
2023-02-18 18:18:11,427 buildarr:49108 buildarr.plugins.dummy default [INFO] Finished updating remote configuration
```

Some improvements have been made to the plugin interface to facilitate better design in implementing plugins. These design changes are optional from the implementing plugin's perspective, which is why the Sonarr plugin has not been updated. This will be done in a separate PR.

* Change `SecretsPlugin` to be a generic class with a `ConfigPlugin` as a class argument, and vice versa
    * This allows any method taking in the corresponding `SecretsPlugin` or `ConfigPlugin` as an argument to specify the implementing type in the type hint, instead of the generic type and using `typing.cast` to set the type hint within the method
    * This wasn't originally done in 0.1.0 because using `TypeVar`s with an actual bound class passed to it results in a cyclic dependency, but it turns out a string representing the class's name can be passed instead, making this possible