### PR TITLE
Fix updates to Sonarr backup general settings

### DIFF
--- a/buildarr/plugins/sonarr/config/general.py
+++ b/buildarr/plugins/sonarr/config/general.py
@@ -456,15 +456,19 @@ class BackupGeneralSettings(GeneralSettings):
     Relative paths will be under Sonarr's AppData directory.
     """
 
-    interval: int = Field(7, ge=0)  # days
+    interval: int = Field(7, ge=1, le=7)  # days
     """
     Interval between automatic backups, in days.
+
+    Must be set somewhere between 1 and 7 days.
     """
 
-    retention: int = Field(28, ge=0)  # days
+    retention: int = Field(28, ge=1, le=90)  # days
     """
     Retention period for backups, in days.
     Backups older than the retention period will be cleaned up automatically.
+
+    Must be set somewhere between 1 and 90 days.
     """
 
     _remote_map: List[RemoteMapEntry] = [

--- a/docs/plugins/sonarr/configuration/general.md
+++ b/docs/plugins/sonarr/configuration/general.md
@@ -22,7 +22,7 @@ sonarr:
       updates:
         branch: "main"
         automatic: false
-        update_mechanism: "docker"
+        mechanism: "docker"
       backup:
         folder: "Backups"
         interval: 7


### PR DESCRIPTION
Fix the ranges of General -> Backup -> Interval and General -> Backup -> Retention so that it isn't possible to specify a value greater than or less than the value accepted by Sonarr.

Fix an error in the documentation where `mechanism` in the `updates` section of general settings was mistakenly referred to as `update_mechanism`.