### PR TITLE
Improve and fix Sonarr general settings configuration updates

### DIFF
--- a/docs/plugins/sonarr/configuration/general.md
+++ b/docs/plugins/sonarr/configuration/general.md
@@ -12,7 +12,7 @@ sonarr:
         url_base: null
         instance_name: "Sonarr (Example)"
       security:
-        authentication_method: "none"
+        authentication: "none"
       proxy:
         enable: false
       logging:


### PR DESCRIPTION
This fixes the remaining issues for pushing configuration updates for Sonarr general settings.

* Fix updates for `sonarr.settings.general.proxy.password`.
* Improve Sonarr instance authentication username and password handling so that it more closely matches the Sonarr instance state:
    * Sonarr does not set the username and password back to blank values once set to a non-zero value, even when authentication is also disabled.
    * To handle this, implement a validator that enforces the following conditions:
        * When authentication is explicitly disabled in either Buildarr or the remote Sonarr instance, set the username and password to `None`. This prevents meaningless configuration updates from Buildarr from occurring.
        * Require the username and password to be set to a non-empty value if authentication is enabled in Buildarr.
* Fix a definition of `sonarr.settings.general.security.authentication` mistakenly set as `authentication_method` in the documentation.