### PR TITLE
Fix small bug Sonarr metadata definition update logging

### DIFF
--- a/buildarr/plugins/sonarr/config/metadata.py
+++ b/buildarr/plugins/sonarr/config/metadata.py
@@ -322,21 +322,21 @@ class SonarrMetadataSettingsConfig(ConfigBase):
         return any(
             [
                 self.kodi_emby._update_remote(
-                    tree=tree,
+                    tree=f"{tree}.kodi_emby",
                     secrets=secrets,
                     remote=remote.kodi_emby,
                     metadata=kodi_emby_metadata,
                     check_unmanaged=check_unmanaged,
                 ),
                 self.roksbox._update_remote(
-                    tree=tree,
+                    tree=f"{tree}.roksbox",
                     secrets=secrets,
                     remote=remote.roksbox,
                     metadata=roksbox_metadata,
                     check_unmanaged=check_unmanaged,
                 ),
                 self.wdtv._update_remote(
-                    tree=tree,
+                    tree=f"{tree}.wdtv",
                     secrets=secrets,
                     remote=remote.wdtv,
                     metadata=wdtv_metadata,


### PR DESCRIPTION
The metadata type wasn't being added to the configuration tree representation, so the type of metadata being updated wasn't shown.

Before:

```
2023-02-19 14:38:51,829 buildarr:51760 buildarr.plugins.sonarr default [INFO] sonarr.settings.metadata.enable: True -> False
2023-02-19 14:38:51,829 buildarr:51760 buildarr.plugins.sonarr default [INFO] sonarr.settings.metadata.series_metadata: False -> True
2023-02-19 14:38:51,830 buildarr:51760 buildarr.plugins.sonarr default [INFO] sonarr.settings.metadata.series_metadata_url: False -> True
2023-02-19 14:38:51,830 buildarr:51760 buildarr.plugins.sonarr default [INFO] sonarr.settings.metadata.episode_metadata: False -> True
2023-02-19 14:38:51,830 buildarr:51760 buildarr.plugins.sonarr default [INFO] sonarr.settings.metadata.series_images: False -> True
2023-02-19 14:38:51,831 buildarr:51760 buildarr.plugins.sonarr default [INFO] sonarr.settings.metadata.season_images: False -> True
2023-02-19 14:38:51,831 buildarr:51760 buildarr.plugins.sonarr default [INFO] sonarr.settings.metadata.episode_images: False -> True
2023-02-19 14:38:51,972 buildarr:51760 buildarr.plugins.sonarr default [INFO] sonarr.settings.metadata.enable: True -> False
2023-02-19 14:38:51,973 buildarr:51760 buildarr.plugins.sonarr default [INFO] sonarr.settings.metadata.episode_metadata: False -> True
2023-02-19 14:38:51,973 buildarr:51760 buildarr.plugins.sonarr default [INFO] sonarr.settings.metadata.series_images: False -> True
2023-02-19 14:38:51,973 buildarr:51760 buildarr.plugins.sonarr default [INFO] sonarr.settings.metadata.season_images: False -> True
2023-02-19 14:38:51,974 buildarr:51760 buildarr.plugins.sonarr default [INFO] sonarr.settings.metadata.episode_images: False -> True
2023-02-19 14:38:52,058 buildarr:51760 buildarr.plugins.sonarr default [INFO] sonarr.settings.metadata.enable: True -> False
2023-02-19 14:38:52,059 buildarr:51760 buildarr.plugins.sonarr default [INFO] sonarr.settings.metadata.episode_metadata: False -> True
2023-02-19 14:38:52,059 buildarr:51760 buildarr.plugins.sonarr default [INFO] sonarr.settings.metadata.series_images: False -> True
2023-02-19 14:38:52,059 buildarr:51760 buildarr.plugins.sonarr default [INFO] sonarr.settings.metadata.season_images: False -> True
2023-02-19 14:38:52,060 buildarr:51760 buildarr.plugins.sonarr default [INFO] sonarr.settings.metadata.episode_images: False -> True
```

After:
```
2023-02-19 14:40:15,227 buildarr:37580 buildarr.plugins.sonarr default [INFO] sonarr.settings.metadata.kodi_emby.enable: False -> True
2023-02-19 14:40:15,227 buildarr:37580 buildarr.plugins.sonarr default [INFO] sonarr.settings.metadata.kodi_emby.series_metadata: True -> False
2023-02-19 14:40:15,227 buildarr:37580 buildarr.plugins.sonarr default [INFO] sonarr.settings.metadata.kodi_emby.series_metadata_url: True -> False
2023-02-19 14:40:15,228 buildarr:37580 buildarr.plugins.sonarr default [INFO] sonarr.settings.metadata.kodi_emby.episode_metadata: True -> False
2023-02-19 14:40:15,228 buildarr:37580 buildarr.plugins.sonarr default [INFO] sonarr.settings.metadata.kodi_emby.series_images: True -> False
2023-02-19 14:40:15,228 buildarr:37580 buildarr.plugins.sonarr default [INFO] sonarr.settings.metadata.kodi_emby.season_images: True -> False
2023-02-19 14:40:15,228 buildarr:37580 buildarr.plugins.sonarr default [INFO] sonarr.settings.metadata.kodi_emby.episode_images: True -> False
2023-02-19 14:40:15,312 buildarr:37580 buildarr.plugins.sonarr default [INFO] sonarr.settings.metadata.roksbox.enable: False -> True
2023-02-19 14:40:15,312 buildarr:37580 buildarr.plugins.sonarr default [INFO] sonarr.settings.metadata.roksbox.episode_metadata: True -> False
2023-02-19 14:40:15,313 buildarr:37580 buildarr.plugins.sonarr default [INFO] sonarr.settings.metadata.roksbox.series_images: True -> False
2023-02-19 14:40:15,313 buildarr:37580 buildarr.plugins.sonarr default [INFO] sonarr.settings.metadata.roksbox.season_images: True -> False
2023-02-19 14:40:15,314 buildarr:37580 buildarr.plugins.sonarr default [INFO] sonarr.settings.metadata.roksbox.episode_images: True -> False
2023-02-19 14:40:44,625 buildarr:58208 buildarr.plugins.sonarr default [INFO] sonarr.settings.metadata.wdtv.enable: False -> True
2023-02-19 14:40:44,625 buildarr:58208 buildarr.plugins.sonarr default [INFO] sonarr.settings.metadata.wdtv.episode_metadata: True -> False
2023-02-19 14:40:44,625 buildarr:58208 buildarr.plugins.sonarr default [INFO] sonarr.settings.metadata.wdtv.series_images: True -> False
2023-02-19 14:40:44,626 buildarr:58208 buildarr.plugins.sonarr default [INFO] sonarr.settings.metadata.wdtv.season_images: True -> False
2023-02-19 14:40:44,626 buildarr:58208 buildarr.plugins.sonarr default [INFO] sonarr.settings.metadata.wdtv.episode_images: True -> False
```