### PR TITLE
Quality/language/release profile and quality definition parser fixes

### DIFF
--- a/buildarr/plugins/sonarr/config/profiles/release.py
+++ b/buildarr/plugins/sonarr/config/profiles/release.py
@@ -22,7 +22,6 @@ Sonarr plugin release profile configuration.
 from __future__ import annotations
 
 import json
-import sys
 
 from pathlib import Path
 from typing import Any, Dict, Iterable, List, Mapping, Optional, Set, cast
@@ -201,10 +200,7 @@ class ReleaseProfile(SonarrConfigBase):
 
     @validator("preferred")
     def sort_preferred(cls, preferred: Iterable[PreferredWord]) -> List[PreferredWord]:
-        return sorted(
-            preferred,
-            key=lambda q: ((sys.maxsize - q.score), q.term),
-        )
+        return sorted(preferred, key=lambda p: (-p.score, p.term))
 
     @classmethod
     def _get_remote_map(
@@ -384,6 +380,11 @@ class ReleaseProfile(SonarrConfigBase):
     def _delete_remote(self, tree: str, secrets: SonarrSecrets, profile_id: int) -> None:
         plugin_logger.info("%s: (...) -> (deleted)", tree)
         api_delete(secrets, f"/api/v3/releaseprofile/{profile_id}")
+
+    # Tell Pydantic to validate in-place assignments of attributes.
+    # This ensures that any validators that parse attributes to consistent values run.
+    class Config(SonarrConfigBase.Config):
+        validate_assignment = True
 
 
 class SonarrReleaseProfilesSettingsConfig(SonarrConfigBase):

--- a/buildarr/plugins/sonarr/config/quality.py
+++ b/buildarr/plugins/sonarr/config/quality.py
@@ -214,3 +214,8 @@ class SonarrQualitySettingsConfig(ConfigBase):
                 )
                 changed = True
         return changed
+
+    # Tell Pydantic to validate in-place assignments of attributes.
+    # This ensures that any validators that parse attributes to consistent values run.
+    class Config(SonarrConfigBase.Config):
+        validate_assignment = True

--- a/docs/plugins/sonarr/configuration/profiles/language.md
+++ b/docs/plugins/sonarr/configuration/profiles/language.md
@@ -7,8 +7,6 @@ sonarr:
   settings:
     profiles:
       language_profiles:
-        # Set to `true` or `false` as desired. (Default `false`)
-        delete_unmanaged: true
         definitions:
           # Add language profiles here.
           # The name of the block becomes the name of the quality profile.
@@ -16,7 +14,7 @@ sonarr:
             upgrades_allowed: true
             upgrade_until: "Japanese"
             # Highest priority quality first, lowest priority goes last.
-            qualities:
+            languages:
               - "Japanese"
               - "English"
           # Add additional language profiles here as needed.


### PR DESCRIPTION
Implement additional validation of quality, language, release profile and quality definitions to ensure proper error checking and consistent value parsing. Also fix a number of small bugs.

* Refactor the quality profile root validator to be easier to understand, and include setting `upgrade_until` to `None` if `upgrades_allowed` is `False` to ensure Buildarr ignores the remote value when upgrades are disabled
* Refactor the quality profile remote map entries to be easier to understand
* Sonarr requires a valid value for `upgrade_until` even if upgrading is disabled, so fix `upgrade_until` encoding when set to `None` by sending the value of the highest enabled quality instead (this fix applies to both quality and language profiles)
* Add the same checks that are used in quality profiles into the language profile parser:
    * `upgrade_until` is required if upgrades are enabled
    * Set `upgrade_until` to `None` if upgrades are disabled
    * Reject duplicate language declarations
* Enable validation of in-place assignments on release profiles and quality definitions, to ensure the values loaded from TRaSH-Guides profiles are valid, but also allow processing validators (e.g. sorting on release profiles) to run
* Simplify release profile preferred word sorting function
* Fix incorrect syntax in language profile definition examples in documentation