### PR TITLE
Fix Sonarr media management settings and improve root folder handling

### DIFF
--- a/docs/plugins/sonarr/configuration/media-management.md
+++ b/docs/plugins/sonarr/configuration/media-management.md
@@ -30,5 +30,6 @@
         - chmod_folder
         - chown_group
         - root_folders
+        - delete_unmanaged_root_folders
       show_root_heading: false
       show_source: false


### PR DESCRIPTION
This fixes a number of bugs with loading and setting media management configuration in Sonarr.

Add a new `delete_unmanaged_root_folders` configuration attribute to the media management block, to enable automatic deletion of root folders not explicitly defined in Buildarr.

* Constrain `minimum_free_space` to the minimum allowed value of 100 MB, as enforced by Sonarr
* Set `chown_group` to be of type `Optional[str]` to allow empty strings to be defined (handled the same as `None`)
* Change `root_folders` to be of type `Set[NonEmptyStr]` to ensure only unique values are handled internally
* Add the `delete_unmanaged_root_folders` attribute for allowing automatic deletion of root folders in Sonarr not defined in Buildarr
* Add the missing `unmonitor_deleted_episodes` to the remote map entries, causing it to not be read from Sonarr or updated when defined in Buildarr
* Fix the root folder tree printed in logging messages to contain `root_folders`