### PR TITLE
Fix GitHub release workflow trigger

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,13 +1,9 @@
 name: release
 
 on:
-  workflow_run:
-    workflows:
-      - pre-commit
-    tags:
-      - "v*.*.*"
+  release:
     types:
-      - completed
+      - published
 
 jobs:
   release:


### PR DESCRIPTION
This changes the trigger for the GitHub release workflow so that it runs when a release is published.

Not as smart as waiting for the other pipelines to finish, but should actually work.