### PR TITLE
Tag v0.1.2

### DIFF
--- a/docs/release-notes.md
+++ b/docs/release-notes.md
@@ -1,5 +1,52 @@
 # Release Notes
 
+## [v0.1.2](https://github.com/buildarr/buildarr/releases/tag/v0.1.2) - 2023-02-20
+
+This is a bugfix release that fixes updates of certain types of Sonarr instance configuration, improving usability of the Sonarr plugin.
+
+The following types of Sonarr instance configuration have had bugfixes and improvements made, and are confirmed to work without errors:
+
+* Media Management
+    * Ensure that `minimum_free_space` is set to a minimum of 100 MB
+    * Fix `unmonitor_deleted_episodes` so that it is now checked and updated by Buildarr
+    * Add a `delete_unmanaged_root_folders` option to allow Buildarr to delete undefined root folders (disabled by default)
+    * Improve other configuration constraints so that it more closely matches Sonarr
+    * Fix a minor logging bug in root folder updates
+* Profiles
+    * Quality Profiles / Language Profiles
+        * Improve attribute constraints e.g. ensure duplicate quality values cannot be defined, enforce `upgrade_until` being required when `allow_upgrades` is `True`
+        * Fix conversion between Buildarr and Sonarr configuration state so that no errors occur when upgrades are disabled
+        * Internal refactor to make the code easier to understand
+    * Delay Profiles - Confirmed to work properly as of `v0.1.1` (and likely `v0.1.0`)
+    * Release Profiles
+        * Fix bug introduced in `v0.1.1` where internal validation is not done on release profiles downloaded from TRaSH-Guides, resulting in preferred word lists being updated on each run, and potential errors not being caught if there are invalid values in the profile
+        * Internal refactor to simplify implementation
+* Quality
+    * Fix bug introduced in `v0.1.1` where internal validation is not done on quality profiles downloaded from TRaSH-Guides, resulting in potential errors not being caught if there are invalid values in the profile
+* Metadata - Confirmed to work properly as of `v0.1.1` (and likely `v0.1.0`)
+    * Small logging bug fixed where it was ambiguous which metadata type was being modified on update
+* Tags - Confirmed to work properly as of `v0.1.1` (and likely `v0.1.0`)
+* General
+    * Improve behaviour when setting an authentication username and password so that configuration updates are idempotent when authentication is disabled
+    * Fix setting a proxy password
+    * Fix setting backup intervals and retentions so that it is no longer possible to set a value not supported by Sonarr
+
+Incorrect syntax in some examples in the documentation were also found and fixed.
+
+### Added
+
+* Added the `sonarr.settings.media_management.delete_unmanaged_root_folders` configuration attribute ([#24](https://github.com/buildarr/buildarr/pull/24))
+
+### Changed
+
+* Improve and fix Sonarr general settings configuration updates ([#19](https://github.com/buildarr/buildarr/pull/19))
+* Fix Sonarr UI settings updates ([#20](https://github.com/buildarr/buildarr/pull/20))
+* Fix small bug Sonarr metadata definition update logging ([#21](https://github.com/buildarr/buildarr/pull/21))
+* Improve Sonarr quality profile definition parsing ([#22](https://github.com/buildarr/buildarr/pull/22))
+* Make improvements and bug fixes to quality/language/release profile and quality definition parsing ([#23](https://github.com/buildarr/buildarr/pull/23))
+* Fix Sonarr media management settings and improve root folder handling ([#24](https://github.com/buildarr/buildarr/pull/24))
+
+
 ## [v0.1.1](https://github.com/buildarr/buildarr/releases/tag/v0.1.1) - 2023-02-19
 
 This is a support release that fixes quality definition and backup configuration updates

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,9 +7,24 @@ build-backend = "poetry.core.masonry.api"
 
 [tool.poetry]
 name = "buildarr"
-version = "0.1.1"
+version = "0.1.2"
 description = "Constructs and configures Arr PVR stacks"
 authors = ["Callum Dickinson <callum.dickinson.nz@gmail.com>"]
+license = "GPL-3.0-or-later"
+homepage = "https://buildarr.github.io"
+repository = "https://github.com/buildarr/buildarr"
+documentation = "https://buildarr.github.io"
+keywords = ["buildarr", "sonarr", "radarr", "prowlarr"]
+classifiers = [
+    "Development Status :: 3 - Alpha",
+    "Framework :: Pydantic",
+    "Intended Audience :: End Users/Desktop",
+    "Natural Language :: English",
+    "Operating System :: OS Independent",
+    "Programming Language :: Python :: 3.8",
+    "Topic :: System :: Systems Administration",
+    "Typing :: Typed"
+]
 readme = "README.md"
 packages = [{include = "buildarr"}]
 


### PR DESCRIPTION
* Set Buildarr version to `0.1.2`
* Add missing PyPI package metadata