### PR TITLE
Implement testing of cached and fetched instance secrets

### DIFF
--- a/buildarr/cli/exceptions.py
+++ b/buildarr/cli/exceptions.py
@@ -52,3 +52,12 @@ class RunNoPluginsDefinedError(BuildarrError):
     """
 
     pass
+
+
+class RunInstanceConnectionTestFailedError(BuildarrError):
+    """
+    Exception raised when a connection test to an instance
+    using Buildarr-fetched secrets failed.
+    """
+
+    pass

--- a/buildarr/plugins/sonarr/secrets.py
+++ b/buildarr/plugins/sonarr/secrets.py
@@ -27,7 +27,8 @@ from urllib.parse import urlparse
 from buildarr.config import NonEmptyStr, Port
 from buildarr.secrets import SecretsPlugin
 
-from .api import get_initialize_js
+from .api import api_get, get_initialize_js
+from .exceptions import SonarrAPIError
 from .util import SonarrApiKey, SonarrProtocol
 
 if TYPE_CHECKING:
@@ -81,3 +82,13 @@ class SonarrSecrets(_SonarrSecrets):
                 config.api_key if config.api_key else get_initialize_js(config.host_url)["apiKey"]
             ),
         )
+
+    def test(self) -> bool:
+        try:
+            api_get(self, "/api/v3/system/status")
+            return True
+        except SonarrAPIError as err:
+            if err.response.status_code == 401:
+                return False
+            else:
+                raise

--- a/buildarr/secrets.py
+++ b/buildarr/secrets.py
@@ -101,6 +101,18 @@ class SecretsPlugin(SecretsBase, Generic[Config]):
         """
         raise NotImplementedError()
 
+    def test(self) -> bool:
+        """
+        Test whether or not the secrets metadata is valid for connecting to the instance.
+
+        This method should be implemented by sending a lightweight `GET` request
+        that requires authentication to the instance.
+
+        Returns:
+            `True` if the test was successful, otherwise `False`
+        """
+        raise NotImplementedError()
+
 
 class SecretsImpl(SecretsBase):
     """


### PR DESCRIPTION
* Add the abstract method for `SecretsPlugin.get` and implement it in the vendored plugins
* Add logic for testing cached secrets, and if the test fails or the secrets are not cached, fetch them and test again
* If even the fetched secrets fail the test, raise an error