### PR TITLE
Convert `Password` and `SonarrApiKey` to subclasses of `SecretStr`

### DIFF
--- a/buildarr/config/__init__.py
+++ b/buildarr/config/__init__.py
@@ -53,24 +53,18 @@ from pydantic import (
     BaseModel,
     ConstrainedInt,
     ConstrainedStr,
-    Field,
     HttpUrl,
     SecretStr,
     create_model,
     root_validator,
 )
 from pydantic.validators import _VALIDATORS
-from typing_extensions import Annotated, Self
+from typing_extensions import Self
 
 from ..logging import logger, plugin_logger
 from ..plugins import Secrets
 from ..state import plugins
 from .util import merge_dicts
-
-Password = Annotated[SecretStr, Field(min_length=1)]
-"""
-Constrained secrets string type for password fields. Required to be non-empty.
-"""
 
 RemoteMapEntry = Tuple[str, str, Mapping[str, Any]]
 """
@@ -117,6 +111,14 @@ class ExampleConfig(ExampleConfigBase):
     ]
 ```
 """
+
+
+class Password(SecretStr):
+    """
+    Constrained secret string type for password fields. Required to be non-empty.
+    """
+
+    min_length = 1
 
 
 class RssUrl(AnyUrl):

--- a/buildarr/plugins/sonarr/util.py
+++ b/buildarr/plugins/sonarr/util.py
@@ -23,8 +23,15 @@ from __future__ import annotations
 
 from typing import Literal
 
-from pydantic import Field, SecretStr
-from typing_extensions import Annotated
+from pydantic import SecretStr
 
-SonarrApiKey = Annotated[SecretStr, Field(min_length=32, max_length=32)]
 SonarrProtocol = Literal["http", "https"]
+
+
+class SonarrApiKey(SecretStr):
+    """
+    Constrained secret string type for a Sonarr API key.
+    """
+
+    min_length = 32
+    max_length = 32


### PR DESCRIPTION
This fixes an error when explicitly defining an API key in a Sonarr instance configuration (and other potential ones).

In some cases (such as this one) API keys and passwords will be passed to configuration model constructors in their object form (rather than a raw string), which, due to a bug in Pydantic, results in a parsing error.