### PR TITLE
Use discriminated unions to accurately determine resource type

### DIFF
--- a/buildarr/plugins/sonarr/config/connect.py
+++ b/buildarr/plugins/sonarr/config/connect.py
@@ -1666,9 +1666,35 @@ CONNECTION_TYPES: Tuple[Type[Connection], ...] = (
     TwitterConnection,
     WebhookConnection,
 )
+
 CONNECTION_TYPE_MAP: Dict[str, Type[Connection]] = {
     connection_type._implementation: connection_type for connection_type in CONNECTION_TYPES
 }
+
+ConnectionType = Union[
+    BoxcarConnection,
+    CustomscriptConnection,
+    DiscordConnection,
+    EmailConnection,
+    EmbyConnection,
+    GotifyConnection,
+    JoinConnection,
+    KodiConnection,
+    MailgunConnection,
+    PlexHomeTheaterConnection,
+    PlexMediaCenterConnection,
+    PlexMediaServerConnection,
+    ProwlConnection,
+    PushbulletConnection,
+    PushoverConnection,
+    SendgridConnection,
+    SlackConnection,
+    SynologyIndexerConnection,
+    TelegramConnection,
+    TraktConnection,
+    TwitterConnection,
+    WebhookConnection,
+]
 
 
 class SonarrConnectSettingsConfig(SonarrConfigBase):
@@ -1684,34 +1710,7 @@ class SonarrConnectSettingsConfig(SonarrConfigBase):
     managed by other applications.
     """
 
-    # TODO: Set minimum Python version to 3.11 and subscript CONNECTION_TYPES here.
-    definitions: Dict[
-        str,
-        Union[
-            BoxcarConnection,
-            CustomscriptConnection,
-            DiscordConnection,
-            EmailConnection,
-            EmbyConnection,
-            GotifyConnection,
-            JoinConnection,
-            KodiConnection,
-            MailgunConnection,
-            PlexHomeTheaterConnection,
-            PlexMediaCenterConnection,
-            PlexMediaServerConnection,
-            ProwlConnection,
-            PushbulletConnection,
-            PushoverConnection,
-            SendgridConnection,
-            SlackConnection,
-            SynologyIndexerConnection,
-            TelegramConnection,
-            TraktConnection,
-            TwitterConnection,
-            WebhookConnection,
-        ],
-    ] = {}
+    definitions: Dict[str, Annotated[ConnectionType, Field(discriminator="type")]] = {}
     """
     Connection definitions to configure in Sonarr.
     """

--- a/buildarr/plugins/sonarr/config/download_clients/__init__.py
+++ b/buildarr/plugins/sonarr/config/download_clients/__init__.py
@@ -21,9 +21,10 @@ Sonarr plugin download client settings.
 
 from __future__ import annotations
 
-from typing import Dict, List, Union
+from typing import Dict, List, Mapping, Union
 
-from typing_extensions import Self
+from pydantic import Field
+from typing_extensions import Annotated, Self
 
 from buildarr.config import RemoteMapEntry
 from buildarr.logging import plugin_logger
@@ -53,28 +54,24 @@ from .download_clients import (
 )
 from .remote_path_mappings import SonarrRemotePathMappingsSettingsConfig
 
-# TODO: Set minimum Python version to 3.11 and subscript DOWNLOADCLIENT_TYPES here.
-DownloadClientDefinitions = Dict[
-    str,
-    Union[
-        DownloadstationUsenetDownloadClient,
-        NzbgetDownloadClient,
-        NzbvortexDownloadClient,
-        PneumaticDownloadClient,
-        SabnzbdDownloadClient,
-        UsenetBlackholeDownloadClient,
-        Aria2DownloadClient,
-        DelugeDownloadClient,
-        DownloadstationTorrentDownloadClient,
-        FloodDownloadClient,
-        HadoukenDownloadClient,
-        QbittorrentDownloadClient,
-        RtorrentDownloadClient,
-        TorrentBlackholeDownloadClient,
-        TransmissionDownloadClient,
-        UtorrentDownloadClient,
-        VuzeDownloadClient,
-    ],
+DownloadClientType = Union[
+    DownloadstationUsenetDownloadClient,
+    NzbgetDownloadClient,
+    NzbvortexDownloadClient,
+    PneumaticDownloadClient,
+    SabnzbdDownloadClient,
+    UsenetBlackholeDownloadClient,
+    Aria2DownloadClient,
+    DelugeDownloadClient,
+    DownloadstationTorrentDownloadClient,
+    FloodDownloadClient,
+    HadoukenDownloadClient,
+    QbittorrentDownloadClient,
+    RtorrentDownloadClient,
+    TorrentBlackholeDownloadClient,
+    TransmissionDownloadClient,
+    UtorrentDownloadClient,
+    VuzeDownloadClient,
 ]
 
 
@@ -126,7 +123,7 @@ class SonarrDownloadClientsSettingsConfig(SonarrConfigBase):
     Automatically delete download clients not defined in Buildarr.
     """
 
-    definitions: DownloadClientDefinitions = {}
+    definitions: Dict[str, Annotated[DownloadClientType, Field(discriminator="type")]] = {}
     """
     Download client definitions, for connecting with external media downloaders.
     """
@@ -213,8 +210,8 @@ class SonarrDownloadClientsSettingsConfig(SonarrConfigBase):
         self,
         tree: str,
         secrets: SonarrSecrets,
-        local: DownloadClientDefinitions,
-        remote: DownloadClientDefinitions,
+        local: Mapping[str, DownloadClientType],
+        remote: Mapping[str, DownloadClientType],
         check_unmanaged: bool,
     ) -> bool:
         changed = False

--- a/buildarr/plugins/sonarr/config/download_clients/download_clients.py
+++ b/buildarr/plugins/sonarr/config/download_clients/download_clients.py
@@ -1805,6 +1805,7 @@ DOWNLOADLCLIENT_TYPES: Tuple[Type[DownloadClient], ...] = (
     UtorrentDownloadClient,
     VuzeDownloadClient,
 )
+
 DOWNLOADCLIENT_TYPE_MAP: Dict[str, Type[DownloadClient]] = {
     downloadclient_type._implementation: downloadclient_type
     for downloadclient_type in DOWNLOADLCLIENT_TYPES

--- a/buildarr/plugins/sonarr/config/import_lists.py
+++ b/buildarr/plugins/sonarr/config/import_lists.py
@@ -26,8 +26,8 @@ import re
 from datetime import datetime
 from typing import Any, Dict, List, Literal, Mapping, Optional, Set, Tuple, Type, Union
 
-from pydantic import ConstrainedStr, HttpUrl, PositiveInt
-from typing_extensions import Self
+from pydantic import ConstrainedStr, Field, HttpUrl, PositiveInt
+from typing_extensions import Annotated, Self
 
 from buildarr.config import ConfigEnum, NonEmptyStr, Password, RemoteMapEntry
 from buildarr.logging import plugin_logger
@@ -620,9 +620,18 @@ IMPORTLIST_TYPES: Tuple[Type[ImportList], ...] = (
     TraktPopularlistImportList,
     TraktUserImportList,
 )
+
 IMPORTLIST_TYPE_MAP: Dict[str, Type[ImportList]] = {
     importlist_type._implementation: importlist_type for importlist_type in IMPORTLIST_TYPES
 }
+
+ImportListType = Union[
+    SonarrImportList,
+    PlexWatchlistImportList,
+    TraktListImportList,
+    TraktPopularlistImportList,
+    TraktUserImportList,
+]
 
 
 class SonarrImportListsSettingsConfig(SonarrConfigBase):
@@ -669,17 +678,7 @@ class SonarrImportListsSettingsConfig(SonarrConfigBase):
     Automatically delete import list excusions not defined in Buildarr.
     """
 
-    # TODO: Set minimum Python version to 3.11 and subscript IMPORTLIST_TYPES here.
-    definitions: Dict[
-        str,
-        Union[
-            SonarrImportList,
-            PlexWatchlistImportList,
-            TraktListImportList,
-            TraktPopularlistImportList,
-            TraktUserImportList,
-        ],
-    ] = {}
+    definitions: Dict[str, Annotated[ImportListType, Field(discriminator="type")]] = {}
     """
     Import list definitions go here.
     """

--- a/buildarr/plugins/sonarr/config/indexers.py
+++ b/buildarr/plugins/sonarr/config/indexers.py
@@ -24,7 +24,7 @@ from __future__ import annotations
 from typing import Any, Dict, List, Literal, Mapping, Optional, Set, Tuple, Type, Union
 
 from pydantic import Field, HttpUrl, PositiveInt
-from typing_extensions import Self
+from typing_extensions import Annotated, Self
 
 from buildarr.config import ConfigEnum, ConfigIntEnum, NonEmptyStr, Password, RemoteMapEntry, RssUrl
 from buildarr.logging import plugin_logger
@@ -882,9 +882,25 @@ INDEXER_TYPES: Tuple[Type[Indexer], ...] = (
     TorrentleechIndexer,
     TorznabIndexer,
 )
+
 INDEXER_TYPE_MAP: Dict[str, Type[Indexer]] = {
     indexer_type._implementation: indexer_type for indexer_type in INDEXER_TYPES
 }
+
+IndexerType = Union[
+    FanzubIndexer,
+    NewznabIndexer,
+    OmgwtfnzbsIndexer,
+    BroadcasthenetIndexer,
+    FilelistIndexer,
+    HdbitsIndexer,
+    IptorrentsIndexer,
+    NyaaIndexer,
+    RarbgIndexer,
+    TorrentrssfeedIndexer,
+    TorrentleechIndexer,
+    TorznabIndexer,
+]
 
 
 class SonarrIndexersSettingsConfig(SonarrConfigBase):
@@ -966,26 +982,9 @@ class SonarrIndexersSettingsConfig(SonarrConfigBase):
     If unsure, leave set at the default of `false`.
     """
 
-    # TODO: Set minimum Python version to 3.11 and subscript INDEXER_TYPES here.
-    definitions: Dict[
-        str,
-        Union[
-            FanzubIndexer,
-            NewznabIndexer,
-            OmgwtfnzbsIndexer,
-            BroadcasthenetIndexer,
-            FilelistIndexer,
-            HdbitsIndexer,
-            IptorrentsIndexer,
-            NyaaIndexer,
-            RarbgIndexer,
-            TorrentrssfeedIndexer,
-            TorrentleechIndexer,
-            TorznabIndexer,
-        ],
-    ] = {}
+    definitions: Dict[str, Annotated[IndexerType, Field(discriminator="type")]] = {}
     """
-    Indexer to manage via Buildarr are defined here.
+    Indexers to manage via Buildarr are defined here.
     """
 
     _remote_map: List[RemoteMapEntry] = [


### PR DESCRIPTION
Pydantic's coercion heuristrics are usually pretty good, but with extremely complex `Union` structures of very similar types it was resulting in some incorrect object parsing when defining a required `type` parameter in some objects (namely, download clients in the Sonarr plugin).

Enabling [smart_union](https://docs.pydantic.dev/usage/model_config/#smart-union) in the configuration models seemed to correct the issue, but ultimately it is still relying on Pydantic's heuristics to get it right.

Thankfully Pydantic supports [discriminated unions](https://docs.pydantic.dev/usage/types/#discriminated-unions-aka-tagged-unions), so this change sets `type` as the discriminator on all resource definition models to ensure Pydantic always uses the correct class for the definition type.