### PR TITLE
Set better constraints on Sonarr configuration attributes

### DIFF
--- a/buildarr/plugins/sonarr/config/general.py
+++ b/buildarr/plugins/sonarr/config/general.py
@@ -22,7 +22,7 @@ Sonarr plugin general settings configuration.
 from __future__ import annotations
 
 from ipaddress import IPv4Address
-from typing import Any, Dict, List, Literal, Mapping, Optional, Tuple, Union
+from typing import Any, Dict, List, Literal, Mapping, Optional, Set, Tuple, Union
 
 from pydantic import Field, root_validator
 from typing_extensions import Self
@@ -148,7 +148,7 @@ class HostGeneralSettings(GeneralSettings):
 
     ssl_port: Port = 9898  # type: ignore[assignment]
     """
-    Enncrypted (HTTPS) listening port for Sonarr.
+    Encrypted (HTTPS) listening port for Sonarr.
 
     If Sonarr is being run via Docker in the default bridge mode,
     this setting shouldn't be changed.
@@ -342,7 +342,7 @@ class ProxyGeneralSettings(GeneralSettings):
     Only enter if authentication is required by the proxy.
     """
 
-    ignored_addresses: List[NonEmptyStr] = []
+    ignored_addresses: Set[NonEmptyStr] = set()
     """
     List of domains/addresses which bypass the proxy. Wildcards (`*`) are supported.
     """
@@ -379,9 +379,9 @@ class ProxyGeneralSettings(GeneralSettings):
             "proxyBypassFilter",
             {
                 "decoder": lambda v: (
-                    [addr.strip() for addr in v.split(",")] if v and v.strip() else []
+                    set(addr.strip() for addr in v.split(",")) if v and v.strip() else []
                 ),
-                "encoder": lambda v: ",".join(v),
+                "encoder": lambda v: ",".join(sorted(v)) if v else "",
             },
         ),
         ("bypass_proxy_for_local_addresses", "proxyBypassLocalAddresses", {}),

--- a/buildarr/plugins/sonarr/config/indexers.py
+++ b/buildarr/plugins/sonarr/config/indexers.py
@@ -515,22 +515,40 @@ class FilelistIndexer(TorrentIndexer):
     as your API key will be sent to this host.
     """
 
-    categories: List[FilelistCategory] = [
+    categories: Set[FilelistCategory] = {
         FilelistCategory.TV_SD,
         FilelistCategory.TV_HD,
         FilelistCategory.TV_4K,
-    ]
+    }
     """
     Categories to monitor for standard/daily show new releases.
 
     Set to an empty list to not monitor for standard/daily shows.
+
+    Values:
+
+    * `Anime`
+    * `Animation`
+    * `TV 4K`
+    * `TV HD`
+    * `TV SD`
+    * `Sport`
     """
 
-    anime_categories: List[FilelistCategory] = []
+    anime_categories: Set[FilelistCategory] = set()
     """
     Categories to monitor for anime new releases.
 
     Leave empty to not monitor for anime.
+
+    Values:
+
+    * `Anime`
+    * `Animation`
+    * `TV 4K`
+    * `TV HD`
+    * `TV SD`
+    * `Sport`
     """
 
     _implementation = "FileList"
@@ -540,8 +558,16 @@ class FilelistIndexer(TorrentIndexer):
         ("username", "username", {"is_field": True}),
         ("passkey", "passKey", {"is_field": True}),
         ("api_url", "apiUrl", {"is_field": True}),
-        ("categories", "categories", {"is_field": True}),
-        ("anime_categories", "animeCategories", {"is_field": True}),
+        (
+            "categories",
+            "categories",
+            {"is_field": True, "encoder": lambda v: sorted(c.value for c in v)},
+        ),
+        (
+            "anime_categories",
+            "animeCategories",
+            {"is_field": True, "encoder": lambda v: sorted(c.value for c in v)},
+        ),
     ]
 
 


### PR DESCRIPTION
* Change the following to use sets instead of lists to handle duplicate elements:
    * `FilelistIndexer.categories`
    * `FilelistIndexer.anime_categories`
    * `DiscordConnection.on_grab_fields`
    * `DiscordConnection.on_import_fields`
    * `JoinConnection.device_names`
    * `PushoverConnection.devices`
    * `ProxyGeneralSettings.ignored_addresses` (`sonarr.settings.general.proxy.ignored_addresses`)
* Make sure recipient/CC/BCC addresses are unique in e-mail, Mailgun and Sendgrid connection definitions
* Require at least recipient address to be provided in Mailgun and Sendgrid connection definitions
 * Fix typos and add missing values descriptions to the documentation