### PR TITLE
Tag v0.2.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -126,45 +126,46 @@ On startup, Buildarr daemon will do an initial sync with the defined instances, 
 After this initial run, Buildarr will wake up at the scheduled times to periodically run updates as required.
 
 ```txt
-2023-02-11 13:43:48,890 buildarr:4308 buildarr.main [INFO] Buildarr version 0.1.0 (log level: INFO)
-2023-02-11 13:43:48,891 buildarr:4308 buildarr.main [INFO] Loading configuration file '/config/buildarr.yml'
-2023-02-11 13:43:48,898 buildarr:4308 buildarr.main [INFO] Finished loading configuration file
-2023-02-11 13:43:48,900 buildarr:4308 buildarr.main [INFO] Daemon configuration:
-2023-02-11 13:43:48,900 buildarr:4308 buildarr.main [INFO]  - Watch configuration files: Yes
-2023-02-11 13:43:48,900 buildarr:4308 buildarr.main [INFO]  - Configuration files to watch:
-2023-02-11 13:43:48,900 buildarr:4308 buildarr.main [INFO]    - /config/buildarr.yml
-2023-02-11 13:43:48,901 buildarr:4308 buildarr.main [INFO]  - Update at:
-2023-02-11 13:43:48,901 buildarr:4308 buildarr.main [INFO]    - Monday 03:00
-2023-02-11 13:43:48,901 buildarr:4308 buildarr.main [INFO]    - Tuesday 03:00
-2023-02-11 13:43:48,901 buildarr:4308 buildarr.main [INFO]    - Wednesday 03:00
-2023-02-11 13:43:48,901 buildarr:4308 buildarr.main [INFO]    - Thursday 03:00
-2023-02-11 13:43:48,901 buildarr:4308 buildarr.main [INFO]    - Friday 03:00
-2023-02-11 13:43:48,901 buildarr:4308 buildarr.main [INFO]    - Saturday 03:00
-2023-02-11 13:43:48,902 buildarr:4308 buildarr.main [INFO]    - Sunday 03:00
-2023-02-11 13:43:48,902 buildarr:4308 buildarr.main [INFO] Applying initial configuration
-2023-02-11 13:43:48,904 buildarr:4308 buildarr.main [INFO] Plugins loaded: sonarr
-2023-02-11 13:43:48,906 buildarr:4308 buildarr.main [INFO] Using plugins: sonarr
-2023-02-11 13:43:48,907 buildarr:4308 buildarr.main [INFO] Loading secrets file from 'secrets.json'
-2023-02-11 13:43:48,909 buildarr:4308 buildarr.main [INFO] Finished loading secrets file
-2023-02-11 13:43:48,910 buildarr:4308 buildarr.plugins.sonarr default [INFO] Checking and fetching secrets
-2023-02-11 13:43:48,910 buildarr:4308 buildarr.plugins.sonarr default [INFO] Finished checking and fetching secrets
-2023-02-11 13:43:48,910 buildarr:4308 buildarr.main [INFO] Saving updated secrets file to 'secrets.json'
-2023-02-11 13:43:48,911 buildarr:4308 buildarr.main [INFO] Finished saving updated secrets file
-2023-02-11 13:43:48,914 buildarr:4308 buildarr.plugins.sonarr default [INFO] Getting remote configuration
-2023-02-11 13:43:49,870 buildarr:4308 buildarr.plugins.sonarr default [INFO] Finished getting remote configuration
-2023-02-11 13:43:49,914 buildarr:4308 buildarr.plugins.sonarr default [INFO] Updating remote configuration
-2023-02-11 13:43:49,954 buildarr:4308 buildarr.plugins.sonarr default [INFO] sonarr.settings.general.host.instance_name: 'Sonarr' -> 'Sonarr (Buildarr Example)'
-2023-02-11 13:43:50,177 buildarr:4308 buildarr.plugins.sonarr default [INFO] Remote configuration successfully updated
-2023-02-11 13:43:50,177 buildarr:4308 buildarr.plugins.sonarr default [INFO] Finished updating remote configuration
-2023-02-11 13:43:50,178 buildarr:4308 buildarr.main [INFO] Finished applying initial configuration
-2023-02-11 13:43:50,179 buildarr:4308 buildarr.main [INFO] Scheduling update jobs
-2023-02-11 13:43:50,180 buildarr:4308 buildarr.main [INFO] Finished scheduling update jobs
-2023-02-11 13:43:50,180 buildarr:4308 buildarr.main [INFO] The next run will be at 2023-02-12 03:00
-2023-02-11 13:43:50,181 buildarr:4308 buildarr.main [INFO] Setting up config file monitoring
-2023-02-11 13:43:50,183 buildarr:4308 buildarr.main [INFO] Finished setting up config file monitoring
-2023-02-11 13:43:50,183 buildarr:4308 buildarr.main [INFO] Setting up signal handlers
-2023-02-11 13:43:50,183 buildarr:4308 buildarr.main [INFO] Finished setting up signal handlers
-2023-02-11 13:43:50,184 buildarr:4308 buildarr.main [INFO] Buildarr ready.
+2023-02-22 21:21:25,047 buildarr:1 buildarr.main [INFO] Buildarr version 0.2.0 (log level: INFO)
+2023-02-22 21:21:25,048 buildarr:1 buildarr.main [INFO] Loading configuration file '/config/buildarr.yml'
+2023-02-22 21:21:25,080 buildarr:1 buildarr.main [INFO] Finished loading configuration file
+2023-02-22 21:21:25,084 buildarr:1 buildarr.main [INFO] Daemon configuration:
+2023-02-22 21:21:25,084 buildarr:1 buildarr.main [INFO]  - Watch configuration files: Yes
+2023-02-22 21:21:25,084 buildarr:1 buildarr.main [INFO]  - Configuration files to watch:
+2023-02-22 21:21:25,085 buildarr:1 buildarr.main [INFO]    - /config/buildarr.yml
+2023-02-22 21:21:25,085 buildarr:1 buildarr.main [INFO]  - Update at:
+2023-02-22 21:21:25,085 buildarr:1 buildarr.main [INFO]    - Monday 03:00
+2023-02-22 21:21:25,085 buildarr:1 buildarr.main [INFO]    - Tuesday 03:00
+2023-02-22 21:21:25,085 buildarr:1 buildarr.main [INFO]    - Wednesday 03:00
+2023-02-22 21:21:25,086 buildarr:1 buildarr.main [INFO]    - Thursday 03:00
+2023-02-22 21:21:25,086 buildarr:1 buildarr.main [INFO]    - Friday 03:00
+2023-02-22 21:21:25,086 buildarr:1 buildarr.main [INFO]    - Saturday 03:00
+2023-02-22 21:21:25,086 buildarr:1 buildarr.main [INFO]    - Sunday 03:00
+2023-02-22 21:21:25,086 buildarr:1 buildarr.main [INFO] Applying initial configuration
+2023-02-22 21:21:25,104 buildarr:1 buildarr.main [INFO] Plugins loaded: sonarr
+2023-02-22 21:21:25,108 buildarr:1 buildarr.main [INFO] Running with plugins: sonarr
+2023-02-22 21:21:25,110 buildarr:1 buildarr.main [INFO] Loading secrets file from '/config/secrets.json'
+2023-02-22 21:21:25,111 buildarr:1 buildarr.main [INFO] Finished loading secrets file
+2023-02-22 21:21:25,112 buildarr:1 buildarr.plugins.sonarr default [INFO] Checking secrets
+2023-02-22 21:21:25,138 buildarr:1 buildarr.plugins.sonarr default [INFO] Connection test successful using cached secrets
+2023-02-22 21:21:25,138 buildarr:1 buildarr.plugins.sonarr default [INFO] Finished checking secrets
+2023-02-22 21:21:25,138 buildarr:1 buildarr.main [INFO] Saving updated secrets file to 'secrets.json'
+2023-02-22 21:21:25,140 buildarr:1 buildarr.main [INFO] Finished saving updated secrets file
+2023-02-22 21:21:26,010 buildarr:1 buildarr.plugins.sonarr default [INFO] Getting remote configuration
+2023-02-22 21:21:26,334 buildarr:1 buildarr.plugins.sonarr default [INFO] Finished getting remote configuration
+2023-02-22 21:21:26,406 buildarr:1 buildarr.plugins.sonarr default [INFO] Updating remote configuration
+2023-02-22 21:21:26,783 buildarr:1 buildarr.plugins.sonarr default [INFO] sonarr.settings.general.host.instance_name: 'Sonarr' -> 'Sonarr (Buildarr Example)'
+2023-02-22 21:21:26,874 buildarr:1 buildarr.plugins.sonarr default [INFO] Remote configuration successfully updated
+2023-02-22 21:21:26,875 buildarr:1 buildarr.plugins.sonarr default [INFO] Finished updating remote configuration
+2023-02-22 21:21:27,220 buildarr:1 buildarr.main [INFO] Finished applying initial configuration
+2023-02-22 21:21:27,221 buildarr:1 buildarr.main [INFO] Scheduling update jobs
+2023-02-22 21:21:27,221 buildarr:1 buildarr.main [INFO] Finished scheduling update jobs
+2023-02-22 21:21:27,222 buildarr:1 buildarr.main [INFO] The next run will be at 2023-02-23 03:00
+2023-02-22 21:21:27,222 buildarr:1 buildarr.main [INFO] Setting up config file monitoring
+2023-02-22 21:21:27,223 buildarr:1 buildarr.main [INFO] Finished setting up config file monitoring
+2023-02-22 21:21:27,223 buildarr:1 buildarr.main [INFO] Setting up signal handlers
+2023-02-22 21:21:27,223 buildarr:1 buildarr.main [INFO] Finished setting up signal handlers
+2023-02-22 21:21:27,223 buildarr:1 buildarr.main [INFO] Buildarr ready.
 ```
 
 For more information on how to interfact with Buildarr, check the [usage documentation](https://buildarr.github.io/usage).

--- a/docs/index.md
+++ b/docs/index.md
@@ -124,45 +124,46 @@ On startup, Buildarr daemon will do an initial sync with the defined instances, 
 After this initial run, Buildarr will wake up at the scheduled times to periodically run updates as required.
 
 ```txt
-2023-02-11 13:43:48,890 buildarr:4308 buildarr.main [INFO] Buildarr version 0.1.0 (log level: INFO)
-2023-02-11 13:43:48,891 buildarr:4308 buildarr.main [INFO] Loading configuration file '/config/buildarr.yml'
-2023-02-11 13:43:48,898 buildarr:4308 buildarr.main [INFO] Finished loading configuration file
-2023-02-11 13:43:48,900 buildarr:4308 buildarr.main [INFO] Daemon configuration:
-2023-02-11 13:43:48,900 buildarr:4308 buildarr.main [INFO]  - Watch configuration files: Yes
-2023-02-11 13:43:48,900 buildarr:4308 buildarr.main [INFO]  - Configuration files to watch:
-2023-02-11 13:43:48,900 buildarr:4308 buildarr.main [INFO]    - /config/buildarr.yml
-2023-02-11 13:43:48,901 buildarr:4308 buildarr.main [INFO]  - Update at:
-2023-02-11 13:43:48,901 buildarr:4308 buildarr.main [INFO]    - Monday 03:00
-2023-02-11 13:43:48,901 buildarr:4308 buildarr.main [INFO]    - Tuesday 03:00
-2023-02-11 13:43:48,901 buildarr:4308 buildarr.main [INFO]    - Wednesday 03:00
-2023-02-11 13:43:48,901 buildarr:4308 buildarr.main [INFO]    - Thursday 03:00
-2023-02-11 13:43:48,901 buildarr:4308 buildarr.main [INFO]    - Friday 03:00
-2023-02-11 13:43:48,901 buildarr:4308 buildarr.main [INFO]    - Saturday 03:00
-2023-02-11 13:43:48,902 buildarr:4308 buildarr.main [INFO]    - Sunday 03:00
-2023-02-11 13:43:48,902 buildarr:4308 buildarr.main [INFO] Applying initial configuration
-2023-02-11 13:43:48,904 buildarr:4308 buildarr.main [INFO] Plugins loaded: sonarr
-2023-02-11 13:43:48,906 buildarr:4308 buildarr.main [INFO] Using plugins: sonarr
-2023-02-11 13:43:48,907 buildarr:4308 buildarr.main [INFO] Loading secrets file from 'secrets.json'
-2023-02-11 13:43:48,909 buildarr:4308 buildarr.main [INFO] Finished loading secrets file
-2023-02-11 13:43:48,910 buildarr:4308 buildarr.plugins.sonarr default [INFO] Checking and fetching secrets
-2023-02-11 13:43:48,910 buildarr:4308 buildarr.plugins.sonarr default [INFO] Finished checking and fetching secrets
-2023-02-11 13:43:48,910 buildarr:4308 buildarr.main [INFO] Saving updated secrets file to 'secrets.json'
-2023-02-11 13:43:48,911 buildarr:4308 buildarr.main [INFO] Finished saving updated secrets file
-2023-02-11 13:43:48,914 buildarr:4308 buildarr.plugins.sonarr default [INFO] Getting remote configuration
-2023-02-11 13:43:49,870 buildarr:4308 buildarr.plugins.sonarr default [INFO] Finished getting remote configuration
-2023-02-11 13:43:49,914 buildarr:4308 buildarr.plugins.sonarr default [INFO] Updating remote configuration
-2023-02-11 13:43:49,954 buildarr:4308 buildarr.plugins.sonarr default [INFO] sonarr.settings.general.host.instance_name: 'Sonarr' -> 'Sonarr (Buildarr Example)'
-2023-02-11 13:43:50,177 buildarr:4308 buildarr.plugins.sonarr default [INFO] Remote configuration successfully updated
-2023-02-11 13:43:50,177 buildarr:4308 buildarr.plugins.sonarr default [INFO] Finished updating remote configuration
-2023-02-11 13:43:50,178 buildarr:4308 buildarr.main [INFO] Finished applying initial configuration
-2023-02-11 13:43:50,179 buildarr:4308 buildarr.main [INFO] Scheduling update jobs
-2023-02-11 13:43:50,180 buildarr:4308 buildarr.main [INFO] Finished scheduling update jobs
-2023-02-11 13:43:50,180 buildarr:4308 buildarr.main [INFO] The next run will be at 2023-02-12 03:00
-2023-02-11 13:43:50,181 buildarr:4308 buildarr.main [INFO] Setting up config file monitoring
-2023-02-11 13:43:50,183 buildarr:4308 buildarr.main [INFO] Finished setting up config file monitoring
-2023-02-11 13:43:50,183 buildarr:4308 buildarr.main [INFO] Setting up signal handlers
-2023-02-11 13:43:50,183 buildarr:4308 buildarr.main [INFO] Finished setting up signal handlers
-2023-02-11 13:43:50,184 buildarr:4308 buildarr.main [INFO] Buildarr ready.
+2023-02-22 21:21:25,047 buildarr:1 buildarr.main [INFO] Buildarr version 0.2.0 (log level: INFO)
+2023-02-22 21:21:25,048 buildarr:1 buildarr.main [INFO] Loading configuration file '/config/buildarr.yml'
+2023-02-22 21:21:25,080 buildarr:1 buildarr.main [INFO] Finished loading configuration file
+2023-02-22 21:21:25,084 buildarr:1 buildarr.main [INFO] Daemon configuration:
+2023-02-22 21:21:25,084 buildarr:1 buildarr.main [INFO]  - Watch configuration files: Yes
+2023-02-22 21:21:25,084 buildarr:1 buildarr.main [INFO]  - Configuration files to watch:
+2023-02-22 21:21:25,085 buildarr:1 buildarr.main [INFO]    - /config/buildarr.yml
+2023-02-22 21:21:25,085 buildarr:1 buildarr.main [INFO]  - Update at:
+2023-02-22 21:21:25,085 buildarr:1 buildarr.main [INFO]    - Monday 03:00
+2023-02-22 21:21:25,085 buildarr:1 buildarr.main [INFO]    - Tuesday 03:00
+2023-02-22 21:21:25,085 buildarr:1 buildarr.main [INFO]    - Wednesday 03:00
+2023-02-22 21:21:25,086 buildarr:1 buildarr.main [INFO]    - Thursday 03:00
+2023-02-22 21:21:25,086 buildarr:1 buildarr.main [INFO]    - Friday 03:00
+2023-02-22 21:21:25,086 buildarr:1 buildarr.main [INFO]    - Saturday 03:00
+2023-02-22 21:21:25,086 buildarr:1 buildarr.main [INFO]    - Sunday 03:00
+2023-02-22 21:21:25,086 buildarr:1 buildarr.main [INFO] Applying initial configuration
+2023-02-22 21:21:25,104 buildarr:1 buildarr.main [INFO] Plugins loaded: sonarr
+2023-02-22 21:21:25,108 buildarr:1 buildarr.main [INFO] Running with plugins: sonarr
+2023-02-22 21:21:25,110 buildarr:1 buildarr.main [INFO] Loading secrets file from '/config/secrets.json'
+2023-02-22 21:21:25,111 buildarr:1 buildarr.main [INFO] Finished loading secrets file
+2023-02-22 21:21:25,112 buildarr:1 buildarr.plugins.sonarr default [INFO] Checking secrets
+2023-02-22 21:21:25,138 buildarr:1 buildarr.plugins.sonarr default [INFO] Connection test successful using cached secrets
+2023-02-22 21:21:25,138 buildarr:1 buildarr.plugins.sonarr default [INFO] Finished checking secrets
+2023-02-22 21:21:25,138 buildarr:1 buildarr.main [INFO] Saving updated secrets file to 'secrets.json'
+2023-02-22 21:21:25,140 buildarr:1 buildarr.main [INFO] Finished saving updated secrets file
+2023-02-22 21:21:26,010 buildarr:1 buildarr.plugins.sonarr default [INFO] Getting remote configuration
+2023-02-22 21:21:26,334 buildarr:1 buildarr.plugins.sonarr default [INFO] Finished getting remote configuration
+2023-02-22 21:21:26,406 buildarr:1 buildarr.plugins.sonarr default [INFO] Updating remote configuration
+2023-02-22 21:21:26,783 buildarr:1 buildarr.plugins.sonarr default [INFO] sonarr.settings.general.host.instance_name: 'Sonarr' -> 'Sonarr (Buildarr Example)'
+2023-02-22 21:21:26,874 buildarr:1 buildarr.plugins.sonarr default [INFO] Remote configuration successfully updated
+2023-02-22 21:21:26,875 buildarr:1 buildarr.plugins.sonarr default [INFO] Finished updating remote configuration
+2023-02-22 21:21:27,220 buildarr:1 buildarr.main [INFO] Finished applying initial configuration
+2023-02-22 21:21:27,221 buildarr:1 buildarr.main [INFO] Scheduling update jobs
+2023-02-22 21:21:27,221 buildarr:1 buildarr.main [INFO] Finished scheduling update jobs
+2023-02-22 21:21:27,222 buildarr:1 buildarr.main [INFO] The next run will be at 2023-02-23 03:00
+2023-02-22 21:21:27,222 buildarr:1 buildarr.main [INFO] Setting up config file monitoring
+2023-02-22 21:21:27,223 buildarr:1 buildarr.main [INFO] Finished setting up config file monitoring
+2023-02-22 21:21:27,223 buildarr:1 buildarr.main [INFO] Setting up signal handlers
+2023-02-22 21:21:27,223 buildarr:1 buildarr.main [INFO] Finished setting up signal handlers
+2023-02-22 21:21:27,223 buildarr:1 buildarr.main [INFO] Buildarr ready.
 ```
 
 For more information on how to interfact with Buildarr, check the [usage documentation](usage.md).

--- a/docs/plugins/index.md
+++ b/docs/plugins/index.md
@@ -8,11 +8,11 @@ Successfully installed plugins will be loaded when Buildarr is run. Configured p
 
 ```text
 $ buildarr run
-2023-02-11 14:50:49,356 buildarr:53612 buildarr.main [INFO] Buildarr version 0.1.0 (log level: INFO)
-2023-02-11 14:50:49,357 buildarr:53612 buildarr.main [INFO] Loading configuration file '/config/buildarr.yml'
-2023-02-11 14:50:49,374 buildarr:53612 buildarr.main [INFO] Finished loading configuration file
-2023-02-11 14:50:49,378 buildarr:53612 buildarr.main [INFO] Plugins loaded: sonarr
-2023-02-11 14:50:49,380 buildarr:53612 buildarr.main [INFO] Using plugins: sonarr
+2023-02-22 14:50:49,356 buildarr:1 buildarr.main [INFO] Buildarr version 0.2.0 (log level: INFO)
+2023-02-22 14:50:49,357 buildarr:1 buildarr.main [INFO] Loading configuration file '/config/buildarr.yml'
+2023-02-22 14:50:49,374 buildarr:1 buildarr.main [INFO] Finished loading configuration file
+2023-02-22 14:50:49,378 buildarr:1 buildarr.main [INFO] Plugins loaded: sonarr
+2023-02-22 14:50:49,380 buildarr:1 buildarr.main [INFO] Running with plugins: sonarr
 ...
 ```
 

--- a/docs/plugins/sonarr/index.md
+++ b/docs/plugins/sonarr/index.md
@@ -35,7 +35,7 @@ Now try a `buildarr run`. If the output is similar to the below output, Buildarr
 
 ```bash
 $ buildarr run
-2023-02-22 20:34:43,271 buildarr:1 buildarr.main [INFO] Buildarr version 0.1.2 (log level: INFO)
+2023-02-22 20:34:43,271 buildarr:1 buildarr.main [INFO] Buildarr version 0.2.0 (log level: INFO)
 2023-02-22 20:34:43,271 buildarr:1 buildarr.main [INFO] Loading configuration file '/config/buildarr.yml'
 2023-02-22 20:34:43,308 buildarr:1 buildarr.main [INFO] Finished loading configuration file
 2023-02-22 20:34:43,337 buildarr:1 buildarr.main [INFO] Plugins loaded: sonarr

--- a/docs/release-notes.md
+++ b/docs/release-notes.md
@@ -1,5 +1,35 @@
 # Release Notes
 
+## [v0.2.0](https://github.com/buildarr/buildarr/releases/tag/v0.2.0) - 2023-02-23
+
+This is a feature release that comprehensively refactors the internal structure of Buildarr and the plugin API, and introduces a new, formally defined global state architecture that Buildarr and plugins can utilise.
+
+These changes improve maintainability of the codebase, allow for more accurate type validation of global state objects, make the plugin API easier to understand for developers, and pave the way for planned new features such as configuring instance-to-instance links within Buildarr.
+
+This release also introduces connection testing of cached and auto-retrieved instance secrets, to ensure Buildarr can communicate and authenticate with instances before it tries to update them.
+
+A handful of bugs were fixed, including but not limited to:
+
+* Work around a parsing bug in Pydantic that causes Buildarr to error out when specifying Sonarr instance API keys in the Buildarr configuration
+* More accurate resource type detection eliminating the chance of parsing errors for Sonarr import list, indexer, download client and connection definitions
+* Set better constraints on some Sonarr configuration attributes:
+    * To handle suboptimal configuration (e.g. ignore duplicate elements)
+    * To reject invalid configuration (e.g. require at least one recipient e-mail address on Mailgun and Sendgrid connection types)
+
+### Added
+
+* Implement testing of cached and fetched instance secrets ([#32](https://github.com/buildarr/buildarr/pull/32))
+* Refactor the internals of Buildarr to improve maintainability ([#30](https://github.com/buildarr/buildarr/pull/30))
+
+### Changed
+
+* Convert `Password` and `SonarrApiKey` to subclasses of `SecretStr` ([#34](https://github.com/buildarr/buildarr/pull/34))
+* Fix CLI exception class inheritance ([#35](https://github.com/buildarr/buildarr/pull/35))
+* Use discriminated unions to accurately determine resource type ([#36](https://github.com/buildarr/buildarr/pull/36))
+* Change log types of some TRaSH logs to `INFO` ([#37](https://github.com/buildarr/buildarr/pull/37))
+* Set better constraints on Sonarr configuration attributes ([#38](https://github.com/buildarr/buildarr/pull/38))
+
+
 ## [v0.1.2](https://github.com/buildarr/buildarr/releases/tag/v0.1.2) - 2023-02-20
 
 This is a bugfix release that fixes updates of certain types of Sonarr instance configuration, improving usability of the Sonarr plugin.

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -62,7 +62,7 @@ Executing `buildarr run` will result in something resembling the following outpu
 
 ```text
 $ buildarr run
-2023-02-22 21:21:25,047 buildarr:1 buildarr.main [INFO] Buildarr version 0.1.2 (log level: INFO)
+2023-02-22 21:21:25,047 buildarr:1 buildarr.main [INFO] Buildarr version 0.2.0 (log level: INFO)
 2023-02-22 21:21:25,048 buildarr:1 buildarr.main [INFO] Loading configuration file '/config/buildarr.yml'
 2023-02-22 21:21:25,080 buildarr:1 buildarr.main [INFO] Finished loading configuration file
 2023-02-22 21:21:25,104 buildarr:1 buildarr.main [INFO] Plugins loaded: sonarr
@@ -104,7 +104,7 @@ This is intended to be used to keep a *Arr stack continually up to date, particu
 There are several options for changing how Buildarr daemon runs in the [Buildarr configuration](configuration.md#buildarr-settings).
 
 ```text
-2023-02-22 21:21:25,047 buildarr:1 buildarr.main [INFO] Buildarr version 0.1.2 (log level: INFO)
+2023-02-22 21:21:25,047 buildarr:1 buildarr.main [INFO] Buildarr version 0.2.0 (log level: INFO)
 2023-02-22 21:21:25,048 buildarr:1 buildarr.main [INFO] Loading configuration file '/config/buildarr.yml'
 2023-02-22 21:21:25,080 buildarr:1 buildarr.main [INFO] Finished loading configuration file
 2023-02-22 21:21:25,084 buildarr:1 buildarr.main [INFO] Daemon configuration:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,7 +7,7 @@ build-backend = "poetry.core.masonry.api"
 
 [tool.poetry]
 name = "buildarr"
-version = "0.1.2"
+version = "0.2.0"
 description = "Constructs and configures Arr PVR stacks"
 authors = ["Callum Dickinson <callum.dickinson.nz@gmail.com>"]
 license = "GPL-3.0-or-later"


### PR DESCRIPTION
* Set Buildarr version to `0.2.0`
* Add release notes to the documentation
* Update Buildarr run examples in the documentation