### PR TITLE
Accept local and non-qualified domain names in URLs

### DIFF
--- a/buildarr/config/base.py
+++ b/buildarr/config/base.py
@@ -41,7 +41,7 @@ from typing import (
 
 import yaml
 
-from pydantic import BaseModel, SecretStr
+from pydantic import AnyUrl, BaseModel, SecretStr
 from pydantic.validators import _VALIDATORS
 from typing_extensions import Self
 
@@ -638,6 +638,8 @@ class ConfigBase(BaseModel, Generic[Secrets]):
         """
         if isinstance(value, BaseEnum):
             return value.to_name_str()
+        elif isinstance(value, AnyUrl):
+            return str(value)
         elif isinstance(value, SecretStr):
             return str(value)
         elif isinstance(value, Path):
@@ -693,6 +695,8 @@ class ConfigBase(BaseModel, Generic[Secrets]):
         """
         if isinstance(value, BaseEnum):
             return value.value
+        elif isinstance(value, AnyUrl):
+            return str(value)
         elif isinstance(value, SecretStr):
             return value.get_secret_value()
         elif isinstance(value, (list, set)):

--- a/buildarr/config/buildarr.py
+++ b/buildarr/config/buildarr.py
@@ -25,7 +25,7 @@ from datetime import time
 from pathlib import Path
 from typing import Set
 
-from pydantic import HttpUrl
+from pydantic import AnyHttpUrl
 
 from ..types import DayOfWeek
 from .base import ConfigBase
@@ -122,7 +122,7 @@ class BuildarrConfig(ConfigBase):
     Path to store the Buildarr instance secrets file.
     """
 
-    trash_metadata_download_url: HttpUrl = (
+    trash_metadata_download_url: AnyHttpUrl = (
         "https://github.com/TRaSH-/Guides/archive/refs/heads/master.zip"  # type: ignore[assignment]
     )
     """

--- a/buildarr/plugins/sonarr/config/connect.py
+++ b/buildarr/plugins/sonarr/config/connect.py
@@ -24,7 +24,7 @@ from __future__ import annotations
 from datetime import datetime
 from typing import Any, Dict, List, Literal, Mapping, Optional, Set, Tuple, Type, Union
 
-from pydantic import ConstrainedInt, Field, HttpUrl, NameEmail, SecretStr
+from pydantic import AnyHttpUrl, ConstrainedInt, Field, NameEmail, SecretStr
 from typing_extensions import Annotated, Self
 
 from buildarr.config import RemoteMapEntry
@@ -441,7 +441,7 @@ class DiscordConnection(Connection):
     Type value associated with this kind of connection.
     """
 
-    webhook_url: HttpUrl
+    webhook_url: AnyHttpUrl
     """
     Discord server webhook URL.
     """
@@ -748,7 +748,7 @@ class GotifyConnection(Connection):
     Type value associated with this kind of connection.
     """
 
-    server: HttpUrl
+    server: AnyHttpUrl
     """
     Gotify server URL. (e.g. `http://gotify.example.com:1234`)
     """
@@ -1382,7 +1382,7 @@ class SlackConnection(Connection):
     Type value associated with this kind of connection.
     """
 
-    webhook_url: HttpUrl
+    webhook_url: AnyHttpUrl
     """
     Webhook URL for the Slack channel to send to.
     """
@@ -1621,7 +1621,7 @@ class WebhookConnection(Connection):
     Type value associated with this kind of connection.
     """
 
-    url: HttpUrl
+    url: AnyHttpUrl
     """
     Webhook URL to send notifications to.
     """

--- a/buildarr/plugins/sonarr/config/import_lists.py
+++ b/buildarr/plugins/sonarr/config/import_lists.py
@@ -26,7 +26,7 @@ import re
 from datetime import datetime
 from typing import Any, Dict, List, Literal, Mapping, Optional, Set, Tuple, Type, Union
 
-from pydantic import ConstrainedStr, Field, HttpUrl, PositiveInt
+from pydantic import AnyHttpUrl, ConstrainedStr, Field, PositiveInt
 from typing_extensions import Annotated, Self
 
 from buildarr.config import RemoteMapEntry
@@ -467,7 +467,7 @@ class SonarrImportList(ProgramImportList):
     #   * Add instance support. Specify the name of the other Sonarr instance
     #     as defined in Buildarr, and have Buildarr fill in the rest of the details.
 
-    full_url: HttpUrl
+    full_url: AnyHttpUrl
     """
     URL that this Sonarr instance will use to connect to the source Sonarr instance.
     """

--- a/buildarr/plugins/sonarr/config/indexers.py
+++ b/buildarr/plugins/sonarr/config/indexers.py
@@ -23,7 +23,7 @@ from __future__ import annotations
 
 from typing import Any, Dict, List, Literal, Mapping, Optional, Set, Tuple, Type, Union
 
-from pydantic import Field, HttpUrl, PositiveInt
+from pydantic import AnyHttpUrl, Field, PositiveInt
 from typing_extensions import Annotated, Self
 
 from buildarr.config import RemoteMapEntry
@@ -342,7 +342,7 @@ class NewznabIndexer(UsenetIndexer):
     Type value associated with this kind of indexer.
     """
 
-    url: HttpUrl
+    url: AnyHttpUrl
     """
     URL of the Newznab-compatible indexing site.
     """
@@ -468,7 +468,7 @@ class BroadcasthenetIndexer(TorrentIndexer):
     Type value associated with this kind of indexer.
     """
 
-    api_url: HttpUrl = "https://api.broadcasthe.net"  # type: ignore[assignment]
+    api_url: AnyHttpUrl = "https://api.broadcasthe.net"  # type: ignore[assignment]
     """
     BroadcasTheNet API URL.
     """
@@ -507,7 +507,7 @@ class FilelistIndexer(TorrentIndexer):
     FileList account API key.
     """
 
-    api_url: HttpUrl = "https://filelist.io"  # type: ignore[assignment]
+    api_url: AnyHttpUrl = "https://filelist.io"  # type: ignore[assignment]
     """
     FileList API URL.
 
@@ -591,7 +591,7 @@ class HdbitsIndexer(TorrentIndexer):
     HDBits API key assigned to the account.
     """
 
-    api_url: HttpUrl = "https://hdbits.org"  # type: ignore[assignment]
+    api_url: AnyHttpUrl = "https://hdbits.org"  # type: ignore[assignment]
     """
     HDBits API URL.
 
@@ -652,7 +652,7 @@ class NyaaIndexer(TorrentIndexer):
     Type value associated with this kind of indexer.
     """
 
-    website_url: HttpUrl
+    website_url: AnyHttpUrl
     """
     HTTPS URL for accessing Nyaa.
     """
@@ -688,7 +688,7 @@ class RarbgIndexer(TorrentIndexer):
     Type value associated with this kind of indexer.
     """
 
-    api_url: HttpUrl
+    api_url: AnyHttpUrl
     """
     RARBG API url.
     """
@@ -784,7 +784,7 @@ class TorrentleechIndexer(TorrentIndexer):
     # NOTE: automatic_search and interactive_search are not supported
     # by this indexer, therefore its value is ignored.
 
-    website_url: HttpUrl = "http://rss.torrentleech.org"  # type: ignore[assignment]
+    website_url: AnyHttpUrl = "http://rss.torrentleech.org"  # type: ignore[assignment]
     """
     TorrentLeech feed API URL.
     """
@@ -815,7 +815,7 @@ class TorznabIndexer(TorrentIndexer):
     Type value associated with this kind of indexer.
     """
 
-    url: HttpUrl
+    url: AnyHttpUrl
     """
     URL of the Torznab-compatible indexing site.
     """


### PR DESCRIPTION
* Change all uses of `HttpUrl` to `AnyHttpUrl`
* Fix printing and encoding of URL objects to work as expected when being processed by Buildarr