### PR TITLE
Add the `--dry-run` option to `buildarr run`

### DIFF
--- a/buildarr/cli/run.py
+++ b/buildarr/cli/run.py
@@ -57,6 +57,14 @@ from .exceptions import RunInstanceConnectionTestFailedError, RunNoPluginsDefine
     default=Path.cwd() / "buildarr.yml",
 )
 @click.option(
+    "-D",
+    "--dry-run",
+    "dry_run",
+    is_flag=True,
+    default=False,
+    help="Enable dry-run mode. Update runs are executed, but instances are not modified.",
+)
+@click.option(
     "-p",
     "--plugin",
     "use_plugins",
@@ -69,7 +77,7 @@ from .exceptions import RunInstanceConnectionTestFailedError, RunNoPluginsDefine
         "(can be defined multiple times)"
     ),
 )
-def run(config_path: Path, use_plugins: Set[str]) -> None:
+def run(config_path: Path, dry_run: bool, use_plugins: Set[str]) -> None:
     """
     'buildarr run' main routine.
 
@@ -83,6 +91,12 @@ def run(config_path: Path, use_plugins: Set[str]) -> None:
         package_version("buildarr"),
         logger.log_level,
     )
+
+    if dry_run:
+        logger.info(
+            "Dry-run mode enabled: executing update runs, but will not modify instances",
+        )
+        state.dry_run = True
 
     # Load and validate the Buildarr configuration.
     load_config(path=config_path, use_plugins=use_plugins)

--- a/buildarr/plugins/sonarr/types.py
+++ b/buildarr/plugins/sonarr/types.py
@@ -19,9 +19,12 @@ Sonarr plugin type hints.
 
 from __future__ import annotations
 
-from typing import Literal
+from datetime import datetime, timezone
+from http import HTTPStatus
+from typing import Literal, Optional
 
 from pydantic import SecretStr
+from requests import Response
 
 SonarrProtocol = Literal["http", "https"]
 
@@ -33,3 +36,50 @@ class SonarrApiKey(SecretStr):
 
     min_length = 32
     max_length = 32
+
+
+def create_dryrun_response(
+    method: str,
+    url: str,
+    status_code: Optional[int] = None,
+    content_type: str = "application/json",
+    charset: str = "utf-8",
+    content: str = "{}",
+) -> Response:
+    """
+    A utility class for generating `requests.Response` objects in dry-run mode.
+
+    _extended_summary_
+
+    Args:
+        Response (_type_): _description_
+    """
+
+    response = Response()
+    response.url = url
+    response.headers["Vary"] = "Accept"
+    response.headers["Cache-Control"] = "no-cache, no-store, must-revalidate, max-age=0"
+    response.headers["Pragma"] = "no-cache"
+    response.headers["Expires"] = "0"
+    response.headers["Access-Control-Allow-Origin"] = "*"
+    response.headers["Content-Type"] = f"{content_type}; charset={charset}"
+    response.headers["Server"] = "Mono-HTTPAPI/1.0"
+    response.headers["Date"] = datetime.now(tz=timezone.utc).strftime("%a, %d %b %Y %H:%M:%S %Z")
+    response.headers["Transfer-Encoding"] = "chunked"
+    if status_code is not None:
+        response.status_code = status_code
+    elif method == "POST":
+        response.status_code = int(HTTPStatus.CREATED)
+    elif method == "PUT":
+        response.status_code = int(HTTPStatus.ACCEPTED)
+    elif method == "DELETE":
+        response.status_code = int(HTTPStatus.OK)
+    else:
+        raise ValueError(
+            f"Unsupported HTTP method for creating dry-run response: {str(method)}",
+        )
+    response.encoding = charset
+    if content is not None:
+        response._content = content.encode("UTF-8")
+
+    return response

--- a/buildarr/state.py
+++ b/buildarr/state.py
@@ -58,6 +58,16 @@ class State:
     Whether Buildarr is in testing mode or not.
     """
 
+    dry_run: bool = False
+    """
+    Whether Buildarr is in dry run mode or not.
+
+    When set to `True` under a CLI command that supports it, the command should not
+    perform any action that would change the state of any external instances.
+
+    Custom CLI commands can set this attribute to `True` if they support a dry-run mode.
+    """
+
     plugins: Mapping[str, Plugin] = {}
     """
     The loaded Buildarr plugins, mapped to the plugin's unique name.

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -54,6 +54,7 @@ $ buildarr run [/path/to/config.yml]
 ```
 
 If using Docker, the command would look something like this:
+
 ```bash
 $ docker run --rm -v /path/to/config:/config -e PUID=<PUID> -e PGID=<PGID> callum027/buildarr:latest run [/config/buildarr.yml]
 ```
@@ -90,7 +91,15 @@ Of note in particular is the following line:
 
 When Buildarr detects that the remote configuration differents from the locally defined configuration, the remote configuration will be updated. In this case, Buildarr detected that on the `default` instance configured in the Sonarr plugin, the configured GUI instance name is different from the locally defined value, so it updated the Sonarr instance to reflect the change.
 
-If the run fails for one reason or another, an error message (or exception traceback, depending on the error) will be logged and Buildarr with exit with a non-zero status.
+If the run fails for one reason or another, an error message will be logged and Buildarr with exit with a non-zero status.
+
+Buildarr supports a dry-run mode, so you can check what *would* change on configured instances, before actually applying them. Under this mode, the output of Buildarr itself is almost exactly the same, but any actions logged in the output are not actually performed.
+
+```bash
+$ buildarr run --dry-run
+```
+
+This allows you to test changes in the configuration, or check the current state of remote instances against the configuration before actually committing changes.
 
 ## As a service (daemon mode)
 


### PR DESCRIPTION
Adds the `--dry-run` parameter to the `buildarr run` command, allowing users to check what changes an update run will do before actually applying them.

This adds a new `state.dry_run` state attribute. As even under a dry run mode as much of the regular processing should be done as possible, the actual implementation of mocking API modifications is left to the plugins.

Plugins from this point onward are required to respect the value of the `state.dry_run` attribute when running configuration updates. The Dummy and Sonarr plugins have been updated to reflect this.