### PR TITLE
Add instance-specific configs to global state and fix Sonarr dry-run bug

### DIFF
--- a/buildarr/state.py
+++ b/buildarr/state.py
@@ -30,7 +30,7 @@ if TYPE_CHECKING:
     from pathlib import Path
     from typing import DefaultDict, Generator, Mapping, Optional, Sequence, Set
 
-    from .config import ConfigType
+    from .config import ConfigPlugin, ConfigType
     from .plugins import Plugin
     from .secrets import SecretsType
 
@@ -85,6 +85,11 @@ class State:
     This includes Buildarr configuration and configuration for enabled plugins.
     """
 
+    instance_configs: Mapping[str, Mapping[str, ConfigPlugin]]
+    """
+    Fully qualified configuration objects for each instance, under each plugin.
+    """
+
     secrets: SecretsType
     """
     Currently loaded instance secrets.
@@ -128,6 +133,7 @@ class State:
 
         This state function is internal, and shouldn't be used by plugins.
         """
+        self.instance_configs = None  # type: ignore[assignment]
         self.secrets = None  # type: ignore[assignment]
         self._current_plugin = None  # type: ignore[assignment]
         self._current_instance = None  # type: ignore[assignment]


### PR DESCRIPTION
* Add a new `instance_configs` state attribute that gets populated after all instance-specific configuration gets read, available to use when resolving instance links.
* Use the aforementioned structure to fix a bug when processing Sonarr import lists under dry-run mode, where resources due to be created on the target Sonarr instance by Buildarr (but not yet due to running as a dry-run) resulted in an error due to non-existent resources. Generate a fake ID for the resource that would approximately match what it would actually be if it was created, and use that in the (not actually sent) request.
* This also fixes an issue where in the above case, the error formatting was not done properly, and the user couldn't tell what type if resource whose ID was not found (other than inferring from the name of the resource).