### PR TITLE
Add the `buildarr test-config` command

### DIFF
--- a/buildarr/cli/daemon.py
+++ b/buildarr/cli/daemon.py
@@ -414,7 +414,7 @@ def daemon(
     update_times: Tuple[time, ...],
 ) -> None:
     """
-    'buildarr daemon' command main routine.
+    `buildarr daemon` command main routine.
 
     Args:
         config_path (Path): Buildarr configuration file to load

--- a/buildarr/cli/daemon.py
+++ b/buildarr/cli/daemon.py
@@ -13,7 +13,7 @@
 
 
 """
-'buildarr daemon' CLI command.
+`buildarr daemon` CLI command.
 """
 
 
@@ -34,10 +34,11 @@ from schedule import Job as SchedulerJob, Scheduler  # type: ignore[import]
 from watchdog.events import FileSystemEventHandler  # type: ignore[import]
 from watchdog.observers import Observer  # type: ignore[import]
 
-from ..config import load as load_config
+from ..config import load_config
 from ..logging import logger
 from ..state import state
 from ..types import DayOfWeek
+from ..util import get_absolute_path
 from . import cli
 from .run import _run as run_apply
 
@@ -94,7 +95,9 @@ class Daemon:
         Load the Buildarr configuration from the given file, and set daemon configuration fields.
         """
         # Load the Buildarr configuration, and save the list of files loaded.
+        logger.info("Loading configuration file '%s'", self.config_path)
         load_config(self.config_path)
+        logger.info("Finished loading configuration file")
         # Set watch_config, update_days and update_times from either the
         # command line-provided override value or the value from the configuration.
         buildarr_config = state.config.buildarr
@@ -364,6 +367,7 @@ def parse_time(
         path_type=Path,
     ),
     default=Path.cwd() / "buildarr.yml",
+    callback=lambda ctx, params, path: get_absolute_path(path),
 )
 @click.option(
     "-w/-W",

--- a/buildarr/cli/exceptions.py
+++ b/buildarr/cli/exceptions.py
@@ -32,7 +32,10 @@ class CLIError(BuildarrError):
 
 class DaemonError(CLIError):
     """
-    Exception raised in the 'buildarr daemon' command.
+    Exception raised in the `buildarr daemon` command.
+
+    This also includes exceptions raised in the `buildarr run` command,
+    since it is a subset of this command.
     """
 
     pass
@@ -40,7 +43,15 @@ class DaemonError(CLIError):
 
 class RunError(DaemonError):
     """
-    Exception raised in the 'buildarr run' command.
+    Exception raised in the `buildarr run` command.
+    """
+
+    pass
+
+
+class TestConfigError(CLIError):
+    """
+    Exception raised in the `buildarr test-config` command.
     """
 
     pass
@@ -58,6 +69,15 @@ class RunInstanceConnectionTestFailedError(RunError):
     """
     Exception raised when a connection test to an instance
     using Buildarr-fetched secrets failed.
+    """
+
+    pass
+
+
+class TestConfigNoPluginsDefinedError(TestConfigError):
+    """
+    Configuration test error for when there is no configuration defined
+    for the loaded plugins.
     """
 
     pass

--- a/buildarr/cli/main.py
+++ b/buildarr/cli/main.py
@@ -24,8 +24,9 @@ from __future__ import annotations
 from ..plugins import load as load_plugins
 from ..state import state
 from . import cli as main
-from .daemon import daemon  # noqa: F401
-from .run import run  # noqa: F401
+from .daemon import daemon
+from .run import run
+from .test_config import test_config
 
 __all__ = ["main"]
 

--- a/buildarr/cli/run.py
+++ b/buildarr/cli/run.py
@@ -40,7 +40,7 @@ from .exceptions import RunInstanceConnectionTestFailedError, RunNoPluginsDefine
 
 @cli.command(
     help=(
-        "Configure instances defined in the Buildarr config file, and exit.\n\n"
+        "Update configured instances, and exit.\n\n"
         "If CONFIG-PATH is not defined, use `buildarr.yml' from the current directory."
     ),
 )

--- a/buildarr/cli/run.py
+++ b/buildarr/cli/run.py
@@ -81,10 +81,11 @@ from .exceptions import RunInstanceConnectionTestFailedError, RunNoPluginsDefine
 )
 def run(config_path: Path, dry_run: bool, use_plugins: Set[str]) -> None:
     """
-    'buildarr run' main routine.
+    `buildarr run` main routine.
 
     Args:
         config_path (Path): Configuration file to load.
+        dry_run (bool): If set to `True`, run in dry-run mode.
         plugins (Set[str]): Plugins to load. If empty, use all plugins.
     """
 

--- a/buildarr/cli/run.py
+++ b/buildarr/cli/run.py
@@ -154,7 +154,7 @@ def _run(use_plugins: Optional[Set[str]] = None) -> None:
     logger.info("Resolving instance dependencies")
     resolve_instance_dependencies()
     logger.debug("Execution order:")
-    for i, (plugin_name, instance_name) in enumerate(state._execution_order):
+    for i, (plugin_name, instance_name) in enumerate(state._execution_order, 1):
         logger.debug("%i. %s.instances[%s]", i, plugin_name, repr(instance_name))
     logger.info("Finished resolving instance dependencies")
 

--- a/buildarr/cli/run.py
+++ b/buildarr/cli/run.py
@@ -13,26 +13,26 @@
 
 
 """
-'buildarr run' CLI command.
+`buildarr run` CLI command.
 """
 
 
 from __future__ import annotations
 
 from pathlib import Path
-from tempfile import TemporaryDirectory
-from typing import Dict, List, Optional, Set
+from typing import Dict, Optional, Set
 
 import click
 
 from importlib_metadata import version as package_version
 
-from ..config import ConfigPlugin, ConfigPluginType, load as load_config
+from ..config import load_config, load_instance_configs, resolve_instance_dependencies
 from ..logging import logger, plugin_logger
-from ..manager import ManagerPlugin
-from ..secrets import SecretsPlugin, load as load_secrets
-from ..state import PluginInstanceRef, state
+from ..manager import load_managers
+from ..secrets import SecretsPlugin, load_secrets
+from ..state import state
 from ..trash import fetch as trash_fetch
+from ..util import create_temp_dir, get_absolute_path
 from . import cli
 from .exceptions import RunInstanceConnectionTestFailedError, RunNoPluginsDefinedError
 
@@ -55,6 +55,7 @@ from .exceptions import RunInstanceConnectionTestFailedError, RunNoPluginsDefine
         path_type=Path,
     ),
     default=Path.cwd() / "buildarr.yml",
+    callback=lambda ctx, params, path: get_absolute_path(path),
 )
 @click.option(
     "-D",
@@ -98,8 +99,9 @@ def run(config_path: Path, dry_run: bool, use_plugins: Set[str]) -> None:
         )
         state.dry_run = True
 
-    # Load and validate the Buildarr configuration.
+    logger.info("Loading configuration file '%s'", config_path)
     load_config(path=config_path, use_plugins=use_plugins)
+    logger.info("Finished loading configuration file")
 
     # Run the instance update main function.
     _run(use_plugins)
@@ -122,83 +124,73 @@ def _run(use_plugins: Optional[Set[str]] = None) -> None:
     # Dump the currently active Buildarr configuration file to the debug log.
     logger.debug("Buildarr configuration:\n%s", state.config.yaml(exclude_unset=True))
 
-    # List of plugins with which to run the Buildarr update process.
-    # Only plugins with explicitly defined configurations get run.
-    run_plugins: List[str] = []
-
     # Output the currently loaded plugins to the logs.
     logger.info(
         "Plugins loaded: %s",
         ", ".join(sorted(state.plugins.keys())) if state.plugins else "(no plugins found)",
     )
 
-    # Fetch fully-qualified configurations for each instance under each selected plugin
-    # (or all plugins if `use_plugins` is empty).
-    # The above action is done in an instance-specific context, so that
-    # when the instance-specific configuration gets evaluated by the configuration parser,
-    # instance name references are processed and dependencies get added
-    # to `state._instance_dependencies`.
-    configs: Dict[str, Dict[str, ConfigPlugin]] = {}
-    managers: Dict[str, ManagerPlugin] = {}
-    for plugin_name, plugin in state.plugins.items():
-        if use_plugins and plugin_name not in use_plugins:
-            continue
-        if plugin_name in state.config.__fields_set__:
-            run_plugins.append(plugin_name)
-            plugin_manager = plugin.manager()
-            plugin_config: ConfigPluginType = getattr(state.config, plugin_name)
-            managers[plugin_name] = plugin_manager
-            configs[plugin_name] = {}
-            for instance_name in (
-                plugin_config.instances.keys() if plugin_config.instances else ["default"]
-            ):
-                with state._with_context(plugin_name=plugin_name, instance_name=instance_name):
-                    configs[plugin_name][instance_name] = plugin_manager.get_instance_config(
-                        plugin_config,
-                        instance_name,
-                    )
+    # Load the manager object for each plugin into global state.
+    logger.debug("Loading plugin managers")
+    load_managers(use_plugins)
+    logger.debug("Finished loading plugin managers")
 
-    # Update global application state with the fully qualified instance configurations.
-    state.instance_configs = configs
+    # Parse and validate the instance-specific configurations under each plugin,
+    # and load them into global state.
+    logger.info("Loading instance configurations")
+    load_instance_configs(use_plugins)
+    logger.info("Finished loading instance configurations")
 
     # If no plugins are configured to run, there is nothing more we can do.
     # Stop here.
-    if not run_plugins:
+    if not state.active_plugins:
         raise RunNoPluginsDefinedError("No loaded plugins configured in Buildarr")
 
     # Log the plugins being executed in this Buildarr run.
-    logger.info("Running with plugins: %s", ", ".join(run_plugins))
+    logger.info("Running with plugins: %s", ", ".join(state.active_plugins))
 
-    # Traverse the instance dependency chain structure to determine
-    # the instance update execution order.
-    execution_order = _get_execution_order()
+    # Resolve the instance dependencies fetched from the instance-specific configuration,
+    # and load the determined execution order into global state.
+    logger.info("Resolving instance dependencies")
+    resolve_instance_dependencies()
+    logger.debug("Execution order:")
+    for i, (plugin_name, instance_name) in enumerate(state._execution_order):
+        logger.debug("%i. %s.instances[%s]", i, plugin_name, repr(instance_name))
+    logger.info("Finished resolving instance dependencies")
 
     # Load the secrets file if it exists, and initialise the secrets metadata.
     # If `use_plugins` is undefined, load using all plugins available
     # to preserve cached secrets metadata that isn't used.
-    load_secrets(path=state.config.buildarr.secrets_file_path, use_plugins=use_plugins)
+    secrets_file_path = state.config.buildarr.secrets_file_path
+    logger.info("Loading secrets file from '%s'", secrets_file_path)
+    if load_secrets(path=secrets_file_path, use_plugins=use_plugins):
+        logger.info("Finished loading secrets file")
+    else:
+        logger.info("Secrets file does not exist, will create new file")
 
     # Generate the secrets structure for each plugin and instance,
     # using the old structure cached from file as a base, and
     # fetching them from the remote instance if they don't exist.
-    for plugin_name in run_plugins:
+    for plugin_name in state.active_plugins:
         plugin_secrets: Dict[str, SecretsPlugin] = getattr(state.secrets, plugin_name)
         for instance_name, instance_config in state.instance_configs[plugin_name].items():
             with state._with_context(plugin_name=plugin_name, instance_name=instance_name):
                 plugin_logger.info("Checking secrets")
                 try:
-                    instance_secrets = plugin_secrets[instance_name]
+                    try_instance_secrets = plugin_secrets[instance_name]
                 except KeyError:
-                    instance_secrets = None
-                if instance_secrets and instance_secrets.test():
+                    try_instance_secrets = None
+                if try_instance_secrets and try_instance_secrets.test():
                     plugin_logger.info("Connection test successful using cached secrets")
-                    plugin_secrets[instance_name] = instance_secrets
+                    plugin_secrets[instance_name] = try_instance_secrets
                 else:
                     plugin_logger.info(
                         "Connection test failed using cached secrets (or not cached), "
                         "fetching secrets",
                     )
-                    instance_secrets = state.plugins[plugin_name].secrets.get(instance_config)
+                    instance_secrets: SecretsPlugin = state.plugins[plugin_name].secrets.get(
+                        instance_config,
+                    )
                     if instance_secrets.test():
                         plugin_logger.info("Connection test successful using fetched secrets")
                         plugin_secrets[instance_name] = instance_secrets
@@ -210,16 +202,15 @@ def _run(use_plugins: Optional[Set[str]] = None) -> None:
                 plugin_logger.info("Finished checking secrets")
 
     # Save the latest secrets file to disk.
-    logger.info("Saving updated secrets file to '%s'", state.config.buildarr.secrets_file_path)
-    state.secrets.write(state.config.buildarr.secrets_file_path)
+    logger.info("Saving updated secrets file to '%s'", secrets_file_path)
+    state.secrets.write(secrets_file_path)
     logger.info("Finished saving updated secrets file")
 
     # Check if any instances are configured to get metadata from TRaSH-Guides.
     uses_trash_metadata = False
-    for plugin_name in run_plugins:
-        manager = managers[plugin_name]
+    for plugin_name in state.active_plugins:
         for instance_config in state.instance_configs[plugin_name].values():
-            if manager.uses_trash_metadata(instance_config):
+            if state.managers[plugin_name].uses_trash_metadata(instance_config):
                 uses_trash_metadata = True
                 break
         if uses_trash_metadata:
@@ -227,8 +218,7 @@ def _run(use_plugins: Optional[Set[str]] = None) -> None:
 
     # Create a temporary directory for Buildarr to use.
     logger.debug("Creating runtime directory")
-    with TemporaryDirectory(prefix="buildarr.") as temp_dir_str:
-        temp_dir = Path(temp_dir_str)
+    with create_temp_dir() as temp_dir:
         logger.debug("Finished creating runtime directory")
 
         # If the TRaSH metadata is required, download it
@@ -238,13 +228,15 @@ def _run(use_plugins: Optional[Set[str]] = None) -> None:
             trash_metadata_dir = temp_dir / "trash"
             trash_metadata_dir.mkdir()
             logger.debug("Finished creating TRaSH metadata directory")
+            logger.info("Fetching TRaSH metadata")
             trash_fetch(trash_metadata_dir)
+            logger.info("Finished fetching TRaSH metadata")
         else:
             logger.debug("TRaSH metadata not required")
 
         # Update all instances in the determined execution order.
-        for plugin_name, instance_name in execution_order:
-            manager = managers[plugin_name]
+        for plugin_name, instance_name in state._execution_order:
+            manager = state.managers[plugin_name]
             instance_config = state.instance_configs[plugin_name][instance_name]
             with state._with_context(plugin_name=plugin_name, instance_name=instance_name):
                 # Get the instance's secrets object.
@@ -298,111 +290,3 @@ def _run(use_plugins: Optional[Set[str]] = None) -> None:
                 #     f'{instance_name}' after update:\n"
                 #     f"{pformat(new_active_config.dict(exclude_unset=True))}",
                 # )
-
-
-def _get_execution_order() -> List[PluginInstanceRef]:
-    """
-    Return a list of plugin-instance references in the order which
-    operations should be performed on them.
-
-    This performs a depth-first search on the dependency tree structure
-    stored in `state._instance_dependencies`, which is generated using
-    instance name references defined within Buildarr instance configurations.
-
-    Returns:
-        Execution order of instances specified as a list of (plugin, instance) tuples
-    """
-
-    added_plugin_instances: Set[PluginInstanceRef] = set()
-    execution_order: List[PluginInstanceRef] = []
-
-    logger.info("Resolving instance dependencies")
-    logger.debug("Execution order:")
-
-    for plugin_name, instance_configs in state.instance_configs.items():
-        for instance_name in instance_configs.keys():
-            instance = (plugin_name, instance_name)
-            if instance in added_plugin_instances:
-                continue
-            __get_execution_order(
-                added_plugin_instances=added_plugin_instances,
-                execution_order=execution_order,
-                plugin_name=plugin_name,
-                instance_name=instance_name,
-            )
-
-    logger.info("Finished resolving instance dependencies")
-
-    return execution_order
-
-
-def __get_execution_order(
-    added_plugin_instances: Set[PluginInstanceRef],
-    execution_order: List[PluginInstanceRef],
-    plugin_name: str,
-    instance_name: str,
-    dependency_tree: Optional[List[PluginInstanceRef]] = None,
-) -> None:
-    """
-    Recursive depth-first search function for `get_execution_order`.
-
-    Args:
-        added_plugin_instances (Set[PluginInstanceRef]): Structure to avoid re-evaluating branches.
-        execution_order (List[PluginInstanceRef]): Final data structure, appended to in-place.
-        plugin_name (str): Plugin the current instance being evaluated is under.
-        instance_name (str): Name of instance to evaluate dependencies for.
-        dependency_tree (List[PluginInstanceRef], optional): Tree used to find dependency cycles.
-
-    Raises:
-        ValueError: When a plugin used in an instance reference is not installed
-        ValueError: When a plugin used in an instance reference is disabled or not configured
-        ValueError: When a dependency cycle is detected
-    """
-
-    if not dependency_tree:
-        dependency_tree = []
-
-    plugin_instance: PluginInstanceRef = (plugin_name, instance_name)
-
-    if plugin_name not in state.instance_configs:
-        error_message = 'Unable to resolve instance dependency "'
-        try:
-            previous_pi = dependency_tree[-1]
-            error_message += f"{previous_pi[0]}.instances[{repr(previous_pi[1])}] -> "
-        except IndexError:
-            # Shouldn't happen because dependency keys are generated from
-            # instance configuration, but handle it just in case.
-            pass
-        error_message += f'{plugin_name}.instances[{repr(instance_name)}]": '
-        if plugin_name not in state.plugins:
-            error_message += f"Plugin '{plugin_name}' not installed"
-        else:
-            error_message += f"Plugin '{plugin_name}' disabled, or no configuration defined for it"
-        raise ValueError(error_message)
-
-    if plugin_instance in dependency_tree:
-        raise ValueError(
-            (
-                "Detected dependency cycle in configuration for instance references:\n"
-                + "\n".join(
-                    f"  {i}. {pname}.instances[{repr(iname)}]"
-                    for i, (pname, iname) in enumerate([*dependency_tree, plugin_instance], 1)
-                )
-            ),
-        )
-
-    if plugin_instance in state._instance_dependencies:
-        for target_plugin_instance in state._instance_dependencies[plugin_instance]:
-            if target_plugin_instance not in added_plugin_instances:
-                target_plugin, target_instance = target_plugin_instance
-                __get_execution_order(
-                    added_plugin_instances=added_plugin_instances,
-                    execution_order=execution_order,
-                    plugin_name=target_plugin,
-                    instance_name=target_instance,
-                    dependency_tree=[*dependency_tree, plugin_instance],
-                )
-
-    added_plugin_instances.add(plugin_instance)
-    execution_order.append(plugin_instance)
-    logger.debug("%i. %s.instances[%s]", len(execution_order), plugin_name, repr(instance_name))

--- a/buildarr/cli/test_config.py
+++ b/buildarr/cli/test_config.py
@@ -1,0 +1,204 @@
+# Copyright (C) 2023 Callum Dickinson
+#
+# Buildarr is free software: you can redistribute it and/or modify it under the terms of the
+# GNU General Public License as published by the Free Software Foundation,
+# either version 3 of the License, or (at your option) any later version.
+#
+# Buildarr is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY;
+# without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+# See the GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License along with Buildarr.
+# If not, see <https://www.gnu.org/licenses/>.
+
+
+"""
+`buildarr test-config` CLI command.
+"""
+
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import TYPE_CHECKING
+
+import click
+
+from importlib_metadata import version as package_version
+
+from ..config import load_config, load_instance_configs, resolve_instance_dependencies
+from ..logging import logger, plugin_logger
+from ..manager import load_managers
+from ..state import state
+from ..trash import fetch as trash_fetch
+from ..util import create_temp_dir, get_absolute_path
+from . import cli
+from .exceptions import TestConfigNoPluginsDefinedError
+
+if TYPE_CHECKING:
+    from typing import Set
+
+
+@cli.command(
+    help=(
+        "Test a Buildarr configuration file for correctness.\n\n"
+        "This loads the configuration file and performs a number of checks on it. "
+        "If all tests pass, the file is pretty much guaranteed to work properly "
+        "in a Buildarr run, incorrect values for a remote instance notwithstanding.\n\n"
+        "To validate the configuration against remote instances without modifying them, "
+        "use `buildarr run --dry-run'.\n\n"
+        "If CONFIG-PATH is not defined, use `buildarr.yml' from the current directory."
+    ),
+)
+@click.argument(
+    "config_path",
+    metavar="[CONFIG-PATH]",
+    type=click.Path(
+        exists=True,
+        file_okay=True,
+        dir_okay=False,
+        readable=True,
+        resolve_path=True,
+        path_type=Path,
+    ),
+    default=Path.cwd() / "buildarr.yml",
+    callback=lambda ctx, params, path: get_absolute_path(path),
+)
+@click.option(
+    "-p",
+    "--plugin",
+    "use_plugins",
+    metavar="PLUGIN",
+    type=str,
+    callback=lambda ctx, params, plugins: set(plugins),
+    multiple=True,
+    help=(
+        "Use only the specified Buildarr plugin. Default is to use all installed plugins. "
+        "(can be defined multiple times)"
+    ),
+)
+def test_config(config_path: Path, use_plugins: Set[str]) -> None:
+    """
+    'buildarr test-config' main routine.
+
+    Args:
+        config_path (Path): Configuration file to load.
+        use_plugins (Set[str]): Plugins to load. If empty, use all plugins.
+    """
+
+    logger.info(
+        "Buildarr version %s (log level: %s)",
+        package_version("buildarr"),
+        logger.log_level,
+    )
+    logger.info(
+        "Plugins loaded: %s",
+        ", ".join(sorted(state.plugins.keys())) if state.plugins else "(no plugins found)",
+    )
+    logger.info("Testing configuration file: %s", str(config_path))
+
+    # Load and validate the Buildarr configuration.
+    try:
+        load_config(path=config_path, use_plugins=use_plugins)
+    except Exception:
+        logger.error("Loading configuration: FAILED")
+        raise
+    else:
+        logger.debug("Buildarr configuration:\n%s", state.config.yaml(exclude_unset=True))
+        logger.info("Loading configuration: PASSED")
+
+    # Load the manager objects for the selected plugins.
+    try:
+        load_managers(use_plugins)
+    except Exception:
+        logger.error("Loading plugin managers: FAILED")
+        raise
+    else:
+        logger.debug("Managers loaded for the following plugins:")
+        for plugin_name in state.managers.keys():
+            logger.debug(" - %s", plugin_name)
+        logger.info("Loading plugin managers: PASSED")
+
+    # Parse and validate the instance-specific configurations under each plugin.
+    try:
+        load_instance_configs(use_plugins)
+    except Exception:
+        logger.error("Loading instance configurations: FAILED")
+        raise
+    else:
+        for plugin_name, instance_configs in state.instance_configs.items():
+            for instance_name, instance_config in instance_configs.items():
+                with state._with_context(plugin_name=plugin_name, instance_name=instance_name):
+                    plugin_logger.debug(
+                        "Instance configuration:\n%s",
+                        instance_config.yaml(exclude_unset=True),
+                    )
+        logger.info("Loading instance configurations: PASSED")
+
+    # Check if configuration was found for any selected plugins.
+    if state.active_plugins:
+        logger.debug("Running with plugins: %s", ", ".join(state.active_plugins))
+        logger.info("Checking configured plugins: PASSED")
+    else:
+        logger.error("Checking configured plugins: FAILED")
+        raise TestConfigNoPluginsDefinedError("No configuration defined for any selected plugins")
+
+    # Resolve the instance dependencies fetched from the instance-specific configuration.
+    try:
+        resolve_instance_dependencies()
+    except Exception:
+        logger.error("Resolving instance dependencies: FAILED")
+        raise
+    else:
+        logger.debug("Execution order:")
+        for i, (plugin_name, instance_name) in enumerate(state._execution_order):
+            logger.debug("%i. %s.instances[%s]", i, plugin_name, repr(instance_name))
+        logger.info("Resolving instance dependencies: PASSED")
+
+    # Check if any instances are configured to get metadata from TRaSH-Guides.
+    uses_trash_metadata = False
+    for plugin_name in state.active_plugins:
+        for instance_config in state.instance_configs[plugin_name].values():
+            if state.managers[plugin_name].uses_trash_metadata(instance_config):
+                uses_trash_metadata = True
+                break
+        if uses_trash_metadata:
+            break
+
+    # Skip this test if TRaSH-Guides metadata if no configuration uses it,
+    # but if any do, create a temporary directory, download the TRaSH-Guides metadata,
+    # and render the metadata into the instance-specific configurations.
+    if not uses_trash_metadata:
+        logger.info("Rendering TRaSH-Guides metadata: SKIPPED (not required)")
+    else:
+        logger.debug("Creating runtime directory")
+        with create_temp_dir() as temp_dir:
+            logger.debug("Finished creating runtime directory")
+            logger.debug("Creating TRaSH metadata directory")
+            trash_metadata_dir = temp_dir / "trash"
+            trash_metadata_dir.mkdir()
+            logger.debug("Finished creating TRaSH metadata directory")
+            logger.debug("Fetching TRaSH metadata")
+            trash_fetch(trash_metadata_dir)
+            logger.debug("Finished fetching TRaSH metadata")
+            try:
+                for plugin_name, instance_name in state._execution_order:
+                    manager = state.managers[plugin_name]
+                    with state._with_context(plugin_name=plugin_name, instance_name=instance_name):
+                        if manager.uses_trash_metadata(instance_config):
+                            plugin_logger.debug("Rendering TRaSH-Guides metadata")
+                            state.managers[plugin_name].render_trash_metadata(
+                                state.instance_configs[plugin_name][instance_name],
+                                trash_metadata_dir,
+                            )
+                            plugin_logger.debug("Finished rendering TRaSH-Guides metadata")
+            except Exception:
+                logger.error("Rendering TRaSH-Guides metadata: FAILED")
+                raise
+            else:
+                logger.info("Rendering TRaSH-Guides metadata: PASSED")
+
+    # If we get to this point, this configuration is pretty much guaranteed to be valid.
+    # Incorrect values for a remote application instance notwithstanding, it should
+    # work properly in a real Buildarr run.
+    logger.info("Configuration test successful.")

--- a/buildarr/cli/test_config.py
+++ b/buildarr/cli/test_config.py
@@ -165,8 +165,8 @@ def test_config(config_path: Path, use_plugins: Set[str]) -> None:
         if uses_trash_metadata:
             break
 
-    # Skip this test if TRaSH-Guides metadata if no configuration uses it,
-    # but if any do, create a temporary directory, download the TRaSH-Guides metadata,
+    # Skip this test if no configuration uses TRaSH-Guides metadata,
+    # but otherwise, create a temporary directory, download the TRaSH-Guides metadata,
     # and render the metadata into the instance-specific configurations.
     if not uses_trash_metadata:
         logger.info("Rendering TRaSH-Guides metadata: SKIPPED (not required)")

--- a/buildarr/cli/test_config.py
+++ b/buildarr/cli/test_config.py
@@ -116,7 +116,7 @@ def test_config(config_path: Path, use_plugins: Set[str]) -> None:
     else:
         logger.debug("Managers loaded for the following plugins:")
         for plugin_name in state.managers.keys():
-            logger.debug(" - %s", plugin_name)
+            logger.debug("  - %s", plugin_name)
         logger.info("Loading plugin managers: PASSED")
 
     # Parse and validate the instance-specific configurations under each plugin.
@@ -151,7 +151,7 @@ def test_config(config_path: Path, use_plugins: Set[str]) -> None:
         raise
     else:
         logger.debug("Execution order:")
-        for i, (plugin_name, instance_name) in enumerate(state._execution_order):
+        for i, (plugin_name, instance_name) in enumerate(state._execution_order, 1):
             logger.debug("%i. %s.instances[%s]", i, plugin_name, repr(instance_name))
         logger.info("Resolving instance dependencies: PASSED")
 

--- a/buildarr/cli/test_config.py
+++ b/buildarr/cli/test_config.py
@@ -80,7 +80,7 @@ if TYPE_CHECKING:
 )
 def test_config(config_path: Path, use_plugins: Set[str]) -> None:
     """
-    'buildarr test-config' main routine.
+    `buildarr test-config` main routine.
 
     Args:
         config_path (Path): Configuration file to load.

--- a/buildarr/cli/test_config.py
+++ b/buildarr/cli/test_config.py
@@ -171,7 +171,8 @@ def test_config(config_path: Path, use_plugins: Set[str]) -> None:
     # but otherwise, create a temporary directory, download the TRaSH-Guides metadata,
     # and render the metadata into the instance-specific configurations.
     if not uses_trash_metadata:
-        logger.info("Fetching and rendering TRaSH-Guides metadata: SKIPPED (not required)")
+        logger.info("Fetching TRaSH-Guides metadata: SKIPPED (not required)")
+        logger.info("Rendering TRaSH-Guides metadata: SKIPPED (not required)")
     else:
         logger.debug("Creating TRaSH metadata directory")
         with create_temp_dir() as trash_metadata_dir:

--- a/buildarr/config/__init__.py
+++ b/buildarr/config/__init__.py
@@ -21,8 +21,9 @@ from __future__ import annotations
 
 from .base import ConfigBase
 from .exceptions import ConfigError, ConfigTrashIDNotFoundError
-from .load import load
+from .load import load_config, load_instance_configs
 from .models import ConfigPlugin, ConfigPluginType, ConfigType
+from .resolve_instance_dependencies import resolve_instance_dependencies
 from .types import RemoteMapEntry
 
 __all__ = [
@@ -33,5 +34,7 @@ __all__ = [
     "ConfigType",
     "ConfigPluginType",
     "RemoteMapEntry",
-    "load",
+    "load_config",
+    "load_instance_configs",
+    "resolve_instance_dependencies",
 ]

--- a/buildarr/config/resolve_instance_dependencies.py
+++ b/buildarr/config/resolve_instance_dependencies.py
@@ -37,7 +37,7 @@ def resolve_instance_dependencies() -> None:
     This function requires `config.load_instance_configs` to be run first,
     as that function populates `state._instance_dependencies`, which this function uses.
 
-    A depth-first search on the `state._instance_dependencies` dependency tree structure,
+    A depth-first search on the `state._instance_dependencies` dependency tree structure
     is performed, which is generated using instance name references defined within
     Buildarr instance configurations.
     """

--- a/buildarr/config/resolve_instance_dependencies.py
+++ b/buildarr/config/resolve_instance_dependencies.py
@@ -1,0 +1,131 @@
+# Copyright (C) 2023 Callum Dickinson
+#
+# Buildarr is free software: you can redistribute it and/or modify it under the terms of the
+# GNU General Public License as published by the Free Software Foundation,
+# either version 3 of the License, or (at your option) any later version.
+#
+# Buildarr is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY;
+# without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+# See the GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License along with Buildarr.
+# If not, see <https://www.gnu.org/licenses/>.
+
+
+"""
+Buildarr configuration instance-to-instance dependency resolution functions.
+"""
+
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+from ..state import state
+
+if TYPE_CHECKING:
+    from typing import List, Optional, Set
+
+    from ..state import PluginInstanceRef
+
+
+def resolve_instance_dependencies() -> None:
+    """
+    Generate a list of plugin-instance references in the order which
+    operations should be performed on them, and store it as `state._execution_order`.
+
+    This function requires `config.load_instance_configs` to be run first,
+    as that function populates `state._instance_dependencies`, which this function uses.
+
+    A depth-first search on the `state._instance_dependencies` dependency tree structure,
+    is performed, which is generated using instance name references defined within
+    Buildarr instance configurations.
+    """
+
+    added_plugin_instances: Set[PluginInstanceRef] = set()
+    execution_order: List[PluginInstanceRef] = []
+
+    for plugin_name, instance_configs in state.instance_configs.items():
+        for instance_name in instance_configs.keys():
+            instance = (plugin_name, instance_name)
+            if instance in added_plugin_instances:
+                continue
+            _resolve_instance_dependencies(
+                added_plugin_instances=added_plugin_instances,
+                execution_order=execution_order,
+                plugin_name=plugin_name,
+                instance_name=instance_name,
+            )
+
+    state._execution_order = execution_order
+
+
+def _resolve_instance_dependencies(
+    added_plugin_instances: Set[PluginInstanceRef],
+    execution_order: List[PluginInstanceRef],
+    plugin_name: str,
+    instance_name: str,
+    dependency_tree: Optional[List[PluginInstanceRef]] = None,
+) -> None:
+    """
+    Recursive depth-first search function for `resolve_instance_dependencies`.
+
+    Args:
+        added_plugin_instances (Set[PluginInstanceRef]): Structure to avoid re-evaluating branches.
+        execution_order (List[PluginInstanceRef]): Final data structure, appended to in-place.
+        plugin_name (str): Name of the plugin the current instance being evaluated is under.
+        instance_name (str): Name of the instance to evaluate dependencies for.
+        dependency_tree (List[PluginInstanceRef], optional): Tree used to find dependency cycles.
+
+    Raises:
+        ValueError: When a plugin used in an instance reference is not installed
+        ValueError: When a plugin used in an instance reference is disabled or not configured
+        ValueError: When a dependency cycle is detected
+    """
+
+    if not dependency_tree:
+        dependency_tree = []
+
+    plugin_instance: PluginInstanceRef = (plugin_name, instance_name)
+
+    if plugin_name not in state.instance_configs:
+        error_message = 'Unable to resolve instance dependency "'
+        try:
+            previous_pi = dependency_tree[-1]
+            error_message += f"{previous_pi[0]}.instances[{repr(previous_pi[1])}] -> "
+        except IndexError:
+            # Shouldn't happen because dependency keys are generated from
+            # instance configuration, but handle it just in case.
+            pass
+        error_message += f'{plugin_name}.instances[{repr(instance_name)}]": '
+        if plugin_name not in state.plugins:
+            error_message += f"Plugin '{plugin_name}' not installed"
+        else:
+            error_message += f"Plugin '{plugin_name}' disabled, or no configuration defined for it"
+        raise ValueError(error_message)
+
+    if plugin_instance in dependency_tree:
+        raise ValueError(
+            (
+                "Detected dependency cycle in configuration for instance references:\n"
+                + "\n".join(
+                    f"  {i}. {pname}.instances[{repr(iname)}]"
+                    for i, (pname, iname) in enumerate([*dependency_tree, plugin_instance], 1)
+                )
+            ),
+        )
+
+    if plugin_instance in state._instance_dependencies:
+        for target_plugin_instance in state._instance_dependencies[plugin_instance]:
+            if target_plugin_instance not in added_plugin_instances:
+                target_plugin, target_instance = target_plugin_instance
+                _resolve_instance_dependencies(
+                    added_plugin_instances=added_plugin_instances,
+                    execution_order=execution_order,
+                    plugin_name=target_plugin,
+                    instance_name=target_instance,
+                    dependency_tree=[*dependency_tree, plugin_instance],
+                )
+
+    added_plugin_instances.add(plugin_instance)
+    execution_order.append(plugin_instance)

--- a/buildarr/secrets/__init__.py
+++ b/buildarr/secrets/__init__.py
@@ -20,7 +20,7 @@ Buildarr secrets metadata interface.
 from __future__ import annotations
 
 from .base import SecretsBase
-from .load import load
+from .load import load_secrets
 from .models import SecretsPlugin, SecretsType
 
-__all__ = ["SecretsBase", "SecretsPlugin", "SecretsType", "load"]
+__all__ = ["SecretsBase", "SecretsPlugin", "SecretsType", "load_secrets"]

--- a/buildarr/trash.py
+++ b/buildarr/trash.py
@@ -21,12 +21,12 @@ from __future__ import annotations
 
 from pathlib import Path
 from shutil import move
-from tempfile import TemporaryDirectory
 from urllib.request import urlretrieve
 from zipfile import ZipFile
 
 from .logging import logger
 from .state import state
+from .util import create_temp_dir
 
 
 def fetch(download_dir: Path) -> None:
@@ -38,11 +38,10 @@ def fetch(download_dir: Path) -> None:
         download_dir (Path): Local folder to download the file to
     """
 
-    logger.info("Fetching TRaSH metadata")
-
     logger.debug("Creating TRaSH metadata download temporary directory")
-    with TemporaryDirectory(prefix="buildarr.") as temp_dir_str:
-        temp_dir = Path(temp_dir_str)
+    with create_temp_dir() as temp_dir:
+        logger.debug("Finished creating TRaSH metadata download temporary directory")
+
         trash_metadata_filename = temp_dir / "trash-metadata.zip"
 
         logger.debug("Downloading TRaSH metadata")
@@ -62,5 +61,3 @@ def fetch(download_dir: Path) -> None:
         logger.debug("Finished moving TRaSH metadata files to download directory")
 
         # Temporary directory will be deleted when the with block is exited.
-
-    logger.info("Finished fetching TRaSH metadata")

--- a/buildarr/trash.py
+++ b/buildarr/trash.py
@@ -19,23 +19,48 @@ Buildarr TRaSH-Guides metadata functions.
 
 from __future__ import annotations
 
+from collections import defaultdict
 from pathlib import Path
 from shutil import move
+from typing import TYPE_CHECKING
 from urllib.request import urlretrieve
 from zipfile import ZipFile
 
-from .logging import logger
+from .logging import logger, plugin_logger
 from .state import state
 from .util import create_temp_dir
 
+if TYPE_CHECKING:
+    from typing import DefaultDict, Dict
 
-def fetch(download_dir: Path) -> None:
+    from .config import ConfigPlugin
+
+
+def trash_metadata_used() -> bool:
+    """
+    Read configuration for all loaded instances in the global state, and determine
+    whether or not any of them use TRaSH-Guides metadata.
+
+    Returns:
+        `True` if TRaSH-Guides metadata is used by any instance configuration, otherwise `False`
+    """
+
+    for plugin_name in state.active_plugins:
+        for instance_name, instance_config in state.instance_configs[plugin_name].items():
+            with state._with_context(plugin_name=plugin_name, instance_name=instance_name):
+                if state.managers[plugin_name].uses_trash_metadata(instance_config):
+                    return True
+
+    return False
+
+
+def fetch_trash_metadata(trash_metadata_dir: Path) -> None:
     """
     Download the TRaSH-Guides metadata from the URL specified in the Buildarr config
     to the given local directory.
 
     Args:
-        download_dir (Path): Local folder to download the file to
+        metadata_dir (Path): The local folder to extract the metadata to.
     """
 
     logger.debug("Creating TRaSH metadata download temporary directory")
@@ -53,11 +78,45 @@ def fetch(download_dir: Path) -> None:
             zip_file.extractall(path=temp_dir / "trash-metadata")
         logger.debug("Finished extracting TRaSH metadata")
 
-        logger.debug("Moving TRaSH metadata files to download directory")
+        logger.debug("Moving TRaSH metadata files to target directory")
         for subfile in (
             temp_dir / "trash-metadata" / state.config.buildarr.trash_metadata_dir_prefix
         ).iterdir():
-            move(str(subfile), download_dir)
-        logger.debug("Finished moving TRaSH metadata files to download directory")
+            move(str(subfile), trash_metadata_dir)
+        logger.debug("Finished moving TRaSH metadata files to target directory")
 
         # Temporary directory will be deleted when the with block is exited.
+
+
+def render_trash_metadata(trash_metadata_dir: Path) -> None:
+    """
+    Render TRaSH-Guides metadata on any instance configurations where used,
+    and update the global state.
+
+    Plugins will parse the TRaSH-Guides metadata files in the given directory
+    and return new configuration objects with attributes populated from the metadata.
+
+    Instances that do not use TRaSH-Guides metadata will be left unchanged.
+
+    Args:
+        trash_metadata_dir (Path): Local folder containing TRaSH-Guides metadata files.
+    """
+
+    instance_configs: DefaultDict[str, Dict[str, ConfigPlugin]] = defaultdict(dict)
+
+    for plugin_name, instance_name in state._execution_order:
+        manager = state.managers[plugin_name]
+        instance_config = state.instance_configs[plugin_name][instance_name]
+        with state._with_context(plugin_name=plugin_name, instance_name=instance_name):
+            if manager.uses_trash_metadata(instance_config):
+                plugin_logger.debug("Rendering TRaSH-Guides metadata")
+                instance_configs[plugin_name][instance_name] = manager.render_trash_metadata(
+                    instance_config,
+                    trash_metadata_dir,
+                )
+                plugin_logger.debug("Finished rendering TRaSH-Guides metadata")
+            else:
+                plugin_logger.debug("Skipping rendering TRaSH-Guides metadata (not used)")
+                instance_configs[plugin_name][instance_name] = instance_config
+
+    state.instance_configs = instance_configs

--- a/buildarr/util.py
+++ b/buildarr/util.py
@@ -51,8 +51,8 @@ def get_absolute_path(path: Union[str, os.PathLike]) -> Path:
         Absolute path
     """
 
-    # Path.absolute() does not expand `.` and `..`.
-    # Path.resolve() resolves symbolic links, and has no way to disable it.
+    # `Path.absolute` does not expand `.` and `..`.
+    # `Path.resolve` resolves symbolic links, and has no way to disable it.
     # Using the old `os.path` functions does what we want, so use them.
 
     return Path(os.path.abspath(os.path.expanduser(path)))  # noqa: PTH100 PTH111

--- a/buildarr/util.py
+++ b/buildarr/util.py
@@ -19,29 +19,43 @@ Buildarr general utility functions.
 
 from __future__ import annotations
 
+import os
+
+from contextlib import contextmanager
 from pathlib import Path
+from tempfile import TemporaryDirectory
 from typing import TYPE_CHECKING, Mapping
 
 if TYPE_CHECKING:
-    from os import PathLike
-    from typing import Any, Dict, Union
+    from typing import Any, Dict, Generator, Union
 
 
 __all__ = ["get_absolute_path", "merge_dicts"]
 
 
-def get_absolute_path(path: Union[str, PathLike]) -> Path:
+def get_absolute_path(path: Union[str, os.PathLike]) -> Path:
     """
-    Return the absolute, fully resolved version of the given path.
+    Return the absolute version of the given path, *without* resolving symbolic links.
+
+    The reason why we don't want to resolve symbolic links is because in long lived
+    applications such as daemons, the link target could have changed while the
+    file was not being accessed, therefore making our stored reference to the file invalid.
+
+    Symbolic links should only be resolved when actually accessing the file,
+    without caching the result.
 
     Args:
-        path (Union[str, PathLike]): Path to resolve
+        path (Union[str, os.PathLike]): Path to make absolute.
 
     Returns:
-        Fully resolved absolute path
+        Absolute path
     """
 
-    return Path(path).absolute().resolve()
+    # Path.absolute() does not expand `.` and `..`.
+    # Path.resolve() resolves symbolic links, and has no way to disable it.
+    # Using the old `os.path` functions does what we want, so use them.
+
+    return Path(os.path.abspath(os.path.expanduser(path)))  # noqa: PTH100 PTH111
 
 
 def merge_dicts(*dicts: Mapping[Any, Any]) -> Dict[Any, Any]:
@@ -67,3 +81,22 @@ def merge_dicts(*dicts: Mapping[Any, Any]) -> Dict[Any, Any]:
                 merged_dict[key] = value
 
     return merged_dict
+
+
+@contextmanager
+def create_temp_dir(prefix: str = "buildarr.", **kwargs) -> Generator[Path, None, None]:
+    """
+    Create a temporary directory, give access to it for the executing context,
+    and clean up the directory upon exit from the context.
+
+    Any additional parameters are passed to `tempfile.TemporaryDirectory`.
+
+    Args:
+        prefix (str, optional): Temporary directory name prefix. Defaults to `buildarr.`.
+
+    Yields:
+        Temporary directory path
+    """
+
+    with TemporaryDirectory(prefix=prefix, **kwargs) as temp_dir_str:
+        yield Path(temp_dir_str)

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -2,11 +2,12 @@
 
 Apart from the configuration, most of the interactions with Buildarr are done via the command line.
 
-There are three major operating modes for Buildarr:
+The following commands are available for Buildarr:
 
 * `buildarr run` - Manually perform an update run on one or more instances and exit
 * `buildarr daemon` - Run Buildarr forever: perform an initial update run, and then
   schedule periodic updates
+* `buildarr test-config` - Test a configuration file for correctness (*Added in version 0.4.0*)
 * `buildarr <plugin-name> <command...>` - Ad-hoc commands defined by any loaded plugins
 
 !!! note
@@ -38,9 +39,10 @@ Options:
   --help                          Show this message and exit.
 
 Commands:
-  daemon  Run as a daemon and periodically update defined instances.
-  run     Configure instances defined in the Buildarr config file, and exit.
-  sonarr  Sonarr instance ad-hoc commands.
+  daemon       Run as a daemon and periodically update defined instances.
+  run          Update configured instances, and exit.
+  sonarr       Sonarr instance ad-hoc commands.
+  test-config  Test a Buildarr configuration file for correctness.
 ```
 
 ## Manual runs
@@ -93,7 +95,11 @@ When Buildarr detects that the remote configuration differents from the locally 
 
 If the run fails for one reason or another, an error message will be logged and Buildarr with exit with a non-zero status.
 
-Starting from version 0.4.0, Buildarr supports a dry-run mode, so you can check what *would* change on configured instances, before actually applying them. Under this mode, the output of Buildarr itself is almost exactly the same, but any actions logged in the output are not actually performed.
+### Dry runs
+
+*Added in version 0.4.0.*
+
+Buildarr ad-hoc runs support a dry-run mode, so you can check what *would* change on configured instances, before actually applying them. Under this mode, the output of Buildarr itself is almost exactly the same, but any actions logged in the output are not actually performed.
 
 ```bash
 $ buildarr run --dry-run
@@ -161,6 +167,39 @@ Buildarr daemon supports the following signal types:
 * `SIGHUP` - Reload the Buildarr configuration file and perform an update run
   (the same action taken as when the `watch_config` option is enabled and Buildarr detects configuration changes).
   Not supported on Windows.
+
+## Testing configuration
+
+*Added in version 0.4.0.*
+
+This is a mode for testing whether or not a configuration file is syntactically correct, can be loaded, and contains valid instance-to-instance link references and TRaSH-Guides metadata IDs.
+
+This mode is intended for the user to test that a configuration will be loaded properly by Buildarr, before attempting to connect with any remote instances.
+
+```bash
+$ buildarr test-config [/path/to/config.yml]
+```
+
+If a configuration file is valid, the output from Buildarr will be similar to the following:
+
+```text
+$ buildarr test-config /config/buildarr.yml
+2023-03-19 10:59:27,819 buildarr:1 buildarr.main [INFO] Buildarr version 0.4.0 (log level: INFO)
+2023-03-19 10:59:27,820 buildarr:1 buildarr.main [INFO] Plugins loaded: sonarr
+2023-03-19 10:59:27,820 buildarr:1 buildarr.main [INFO] Testing configuration file: /config/buildarr.yml
+2023-03-19 10:59:27,947 buildarr:1 buildarr.main [INFO] Loading configuration: PASSED
+2023-03-19 10:59:27,947 buildarr:1 buildarr.main [INFO] Loading plugin managers: PASSED
+2023-03-19 10:59:27,971 buildarr:1 buildarr.main [INFO] Loading instance configurations: PASSED
+2023-03-19 10:59:27,971 buildarr:1 buildarr.main [INFO] Checking configured plugins: PASSED
+2023-03-19 10:59:27,971 buildarr:1 buildarr.main [INFO] Resolving instance dependencies: PASSED
+2023-03-19 10:59:31,634 buildarr:1 buildarr.main [INFO] Fetching TRaSH-Guides metadata: PASSED
+2023-03-19 10:59:31,708 buildarr:1 buildarr.main [INFO] Rendering TRaSH-Guides metadata: PASSED
+2023-03-19 10:59:32,053 buildarr:1 buildarr.main [INFO] Configuration test successful.
+```
+
+Since Buildarr does not connect to any remote instances in this mode, even if a configuration file passes the tests performed by `buildarr test-config`, it will not necessarily successfully communicate with them.
+
+To test the configuration against live remote instances, without modifying them, you can use `buildarr run --dry-run` as documented in [Dry runs](#dry-runs).
 
 ## Plugin-specific commands
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -89,6 +89,9 @@ select = [
 extend-select = ["COM812", "COM818", "UP009"]
 extend-ignore = ["A003", "B023", "N805", "N806", "PLR0911", "PLR0912", "PLR0913", "PLR0915"]
 
+[tool.ruff.per-file-ignores]
+"buildarr/cli/main.py" = ["F401"]
+
 [tool.ruff.isort]
 lines-between-types = 1
 combine-as-imports = true


### PR DESCRIPTION
This PR implements the `buildarr test-config` command for testing configuration files.

The main differentiation from `buildarr run --dry-run` is that this checks the configuration as thoroughly as possible *without* communicating with remote instances (except when checking TRaSH-Guides metadata, in which case the latest metadata is downloaded from GitHub).

This allows local running outside of the *Arr stack network, ensuring a file is at least very likely to successfully load within Buildarr before deploying it.

This PR performs a refactor of the CLI command code to allow `buildarr run` and `buildarr test-config` to share as much code as possible, and changes a number of functions to operate on global state instead of using local variables, allowing multiple places to use the most up-to-date instance configurations (with TRaSH-Guides metadata rendered).

Information and debug logging has also been refactored and improved, moving all info logging out of functions (since those are likely to differ between types of commands), and adding additional debug logging output to make it easier to see the actual state Buildarr was in before an error occurs.

Related changes:
* Change the absolute path resolving function to **not** follow symbolic links (since targets can change between Buildarr runs in daemon mode)
* Remove temporary directories after TRaSH-Guides metadata rendering has completed