### PR TITLE
Enable validating default config/secrets attribute values

### DIFF
--- a/buildarr/config/base.py
+++ b/buildarr/config/base.py
@@ -780,6 +780,13 @@ class ConfigBase(BaseModel, Generic[Secrets]):
         # internal name, as well as the alias.
         allow_population_by_field_name = True
 
+        # Validate all configuration attributes, even the default ones.
+        # This is necessary because the default attributes sometimes need to
+        # be validated for correctness in non-default contexts.
+        # (For example, a normally optional attribute becoming required due to
+        # another attribute being enabled.)
+        validate_all = True
+
 
 def _validate_pure_posix_path(v: Any) -> PurePosixPath:
     """

--- a/buildarr/secrets/base.py
+++ b/buildarr/secrets/base.py
@@ -61,5 +61,6 @@ class SecretsBase(BaseModel, Generic[Config]):
         path.write_text(self.json())
 
     class Config:
-        validate_assignment = True
         json_encoders = {SecretStr: lambda v: v.get_secret_value()}
+        validate_all = True
+        validate_assignment = True


### PR DESCRIPTION
To improve validation performance, Pydantic does not validate unset attributes on models by default, as it is assumed that they are always valid.

The value itself may indeed be valid, but in Buildarr, depending on the values set in other attributes, the default value may become inappropriate in certain contexts.

This was manifesting in parameters that are required only in certain cases (e.g. `upgrade_until` when `upgrades_allowed` is enabled on quality and language profiles) not validating their default value, resulting in incorrect configuration being passed as valid unintentionally.

This PR enables `validate_all` on both configuration and secrets models to fix this issue, and enforce validation on **all** attributes, even unset ones with default values.