### PR TITLE
Reduce usage of `initialize.js` endpoints

### DIFF
--- a/buildarr/plugins/dummy/config/__init__.py
+++ b/buildarr/plugins/dummy/config/__init__.py
@@ -27,7 +27,7 @@ from typing_extensions import Self
 from buildarr.config import ConfigPlugin
 from buildarr.types import NonEmptyStr, Port
 
-from ..api import get_initialize_js
+from ..api import api_get
 from ..secrets import DummySecrets
 from ..types import DummyApiKey, DummyProtocol
 from .settings import DummySettingsConfig
@@ -189,10 +189,7 @@ class DummyInstanceConfig(_DummyInstanceConfig):
             port=secrets.port,
             protocol=secrets.protocol,
             api_key=secrets.api_key,
-            version=get_initialize_js(
-                host_url=secrets.host_url,
-                api_key=secrets.api_key.get_secret_value(),
-            )["version"],
+            version=api_get(secrets, "/api/v1/status")["version"],
             settings=DummySettingsConfig.from_remote(secrets),
         )
 

--- a/buildarr/plugins/dummy/server.py
+++ b/buildarr/plugins/dummy/server.py
@@ -116,6 +116,25 @@ def get_initialize_js() -> Tuple[str, int]:
     return (res, 200)
 
 
+@app.get(f"{app.config['API_ROOT']}/status")
+def get_status() -> Tuple[Response, int]:
+    """
+    Return the Dummy server current status.
+
+     ```bash
+    $ curl -H "X-Api-Key: 1a2b3c4d5e" http://localhost:5000/api/v1/status
+    {"version":"0.4.0"}
+    ```
+
+    Returns:
+        Dummy server status
+    """
+
+    check_api_key()
+
+    return (jsonify({"version": package_version("buildarr")}), 200)
+
+
 @app.get(f"{app.config['API_ROOT']}/settings")
 def get_settings() -> Tuple[Response, int]:
     """

--- a/buildarr/plugins/sonarr/config/__init__.py
+++ b/buildarr/plugins/sonarr/config/__init__.py
@@ -27,7 +27,7 @@ from typing_extensions import Self
 from buildarr.config import ConfigPlugin
 from buildarr.types import NonEmptyStr, Port
 
-from ..api import get_initialize_js
+from ..api import api_get
 from ..types import SonarrApiKey, SonarrProtocol
 from .connect import SonarrConnectSettingsConfig
 from .download_clients import SonarrDownloadClientsSettingsConfig
@@ -327,10 +327,7 @@ class SonarrInstanceConfig(_SonarrInstanceConfig):
             port=secrets.port,
             protocol=secrets.protocol,
             api_key=secrets.api_key,
-            version=get_initialize_js(
-                host_url=secrets.host_url,
-                api_key=secrets.api_key.get_secret_value(),
-            )["version"],
+            version=api_get(secrets, "/api/v3/system/status")["version"],
             settings=SonarrSettingsConfig.from_remote(secrets),
         )
 


### PR DESCRIPTION
* Replace one request for `initialize.js` in the Sonarr plugin with a request to `/api/v3/system/status`
* Replace one request for `initialize.js` in the Dummy plugin with a request to a new `/api/v1/status` endpoint