### PR TITLE
Refactor logging infrastructure

### DIFF
--- a/buildarr/cli/__init__.py
+++ b/buildarr/cli/__init__.py
@@ -38,7 +38,7 @@ from ..logging import setup_logger
     "-l",
     "--log-level",
     "log_level",
-    type=click.Choice(["CRITICAL", "ERROR", "WARNING", "INFO", "DEBUG", "NOTSET"]),
+    type=click.Choice(["ERROR", "WARNING", "INFO", "DEBUG"], case_sensitive=False),
     default=os.environ.get("BUILDARR_LOG_LEVEL", "INFO").upper(),
     help=(
         "Buildarr logging system log level. "

--- a/buildarr/cli/daemon.py
+++ b/buildarr/cli/daemon.py
@@ -23,6 +23,7 @@ import itertools
 import signal
 
 from datetime import datetime, time
+from logging import getLogger
 from pathlib import Path
 from time import sleep
 from typing import TYPE_CHECKING, cast
@@ -35,7 +36,7 @@ from watchdog.events import FileSystemEventHandler  # type: ignore[import]
 from watchdog.observers import Observer  # type: ignore[import]
 
 from ..config import load_config
-from ..logging import logger
+from ..logging import get_log_level
 from ..state import state
 from ..types import DayOfWeek
 from ..util import get_absolute_path
@@ -47,6 +48,9 @@ if TYPE_CHECKING:
     from typing import Dict, Iterable, List, Optional, Set, Tuple, Union
 
     from watchdog.events import DirModifiedEvent, FileModifiedEvent  # type: ignore[import]
+
+
+logger = getLogger(__name__)
 
 
 class Daemon:
@@ -455,7 +459,7 @@ def daemon(
     logger.info(
         "Buildarr version %s (log level: %s)",
         package_version("buildarr"),
-        logger.log_level,
+        get_log_level(),
     )
 
     Daemon(

--- a/buildarr/cli/test_config.py
+++ b/buildarr/cli/test_config.py
@@ -19,6 +19,7 @@
 
 from __future__ import annotations
 
+from logging import getLogger
 from pathlib import Path
 from textwrap import indent
 from typing import TYPE_CHECKING
@@ -28,7 +29,7 @@ import click
 from importlib_metadata import version as package_version
 
 from ..config import load_config, load_instance_configs, resolve_instance_dependencies
-from ..logging import logger, plugin_logger
+from ..logging import get_log_level
 from ..manager import load_managers
 from ..state import state
 from ..trash import fetch_trash_metadata, render_trash_metadata
@@ -38,6 +39,9 @@ from .exceptions import TestConfigNoPluginsDefinedError
 
 if TYPE_CHECKING:
     from typing import Set
+
+
+logger = getLogger(__name__)
 
 
 @cli.command(
@@ -90,7 +94,7 @@ def test_config(config_path: Path, use_plugins: Set[str]) -> None:
     logger.info(
         "Buildarr version %s (log level: %s)",
         package_version("buildarr"),
-        logger.log_level,
+        get_log_level(),
     )
     logger.info(
         "Plugins loaded: %s",
@@ -201,11 +205,11 @@ def test_config(config_path: Path, use_plugins: Set[str]) -> None:
                             instance_name=instance_name,
                         ):
                             if state.managers[plugin_name].uses_trash_metadata(instance_config):
-                                plugin_logger.debug("Rendered instance configuration:")
+                                logger.debug("Rendered instance configuration:")
                                 for config_line in instance_config.yaml(
                                     exclude_unset=True,
                                 ).splitlines():
-                                    plugin_logger.debug(indent(config_line, "  "))
+                                    logger.debug(indent(config_line, "  "))
                 logger.info("Rendering TRaSH-Guides metadata: PASSED")
 
     # If we get to this point, this configuration is pretty much guaranteed to be valid.

--- a/buildarr/config/base.py
+++ b/buildarr/config/base.py
@@ -21,6 +21,7 @@ from __future__ import annotations
 
 import json
 
+from logging import getLogger
 from pathlib import Path, PurePosixPath
 from typing import (
     Any,
@@ -44,10 +45,11 @@ from pydantic import AnyUrl, BaseModel, SecretStr
 from pydantic.validators import _VALIDATORS
 from typing_extensions import Self
 
-from ..logging import plugin_logger
 from ..plugins import Secrets
 from ..types import BaseEnum, BaseIntEnum
 from .types import RemoteMapEntry
+
+logger = getLogger(__name__)
 
 OPTIONAL_TYPE_UNION_SIZE = 2
 
@@ -398,17 +400,12 @@ class ConfigBase(BaseModel, Generic[Secrets]):
                 set_value = True
                 value = getattr(self, attr_name)
                 if attr_name not in already_logged:
-                    plugin_logger.info(
-                        "%s.%s: %s -> (created)",
-                        tree,
-                        attr_name,
-                        formatter(value),
-                    )
+                    logger.info("%s.%s: %s -> (created)", tree, attr_name, formatter(value))
                     already_logged.add(attr_name)
             else:
                 set_value = False
                 if attr_name not in already_logged:
-                    plugin_logger.info("%s.%s: (unmanaged)", tree, attr_name)
+                    logger.info("%s.%s: (unmanaged)", tree, attr_name)
                     already_logged.add(attr_name)
             # If the attribute should be set, encode the value and add it
             # to the remote attribute structure in the correct format.
@@ -570,7 +567,7 @@ class ConfigBase(BaseModel, Generic[Secrets]):
                 # value, unless set_unchanged is set to True, do nothing.
                 if local_value == remote_value:
                     if attr_name not in already_logged:
-                        plugin_logger.debug(
+                        logger.debug(
                             "%s.%s: %s (up to date)",
                             tree,
                             attr_name,
@@ -584,7 +581,7 @@ class ConfigBase(BaseModel, Generic[Secrets]):
                 # update the remote value to reflect the changes.
                 else:
                     if attr_name not in already_logged:
-                        plugin_logger.info(
+                        logger.info(
                             "%s.%s: %s -> %s",
                             tree,
                             attr_name,
@@ -602,12 +599,7 @@ class ConfigBase(BaseModel, Generic[Secrets]):
             # If set_unchanged is False, do nothing.
             else:
                 if attr_name not in already_logged:
-                    plugin_logger.debug(
-                        "%s.%s: %s (unmanaged)",
-                        tree,
-                        attr_name,
-                        formatter(remote_value),
-                    )
+                    logger.debug("%s.%s: %s (unmanaged)", tree, attr_name, formatter(remote_value))
                     already_logged.add(attr_name)
                 if attr_metadata.get("set_unchanged", set_unchanged):
                     set_value = True

--- a/buildarr/config/load.py
+++ b/buildarr/config/load.py
@@ -19,6 +19,7 @@ Buildarr configuration loading function.
 
 from __future__ import annotations
 
+from logging import getLogger
 from pathlib import Path
 from typing import TYPE_CHECKING, Type, cast
 
@@ -26,7 +27,6 @@ import yaml
 
 from pydantic import create_model
 
-from ..logging import logger
 from ..state import state
 from ..util import merge_dicts
 from .base import ConfigBase
@@ -37,6 +37,9 @@ if TYPE_CHECKING:
     from typing import Any, Dict, List, Optional, Set, Tuple
 
     from .models import ConfigPlugin, ConfigPluginType
+
+
+logger = getLogger(__name__)
 
 
 def load_config(path: Path, use_plugins: Optional[Set[str]] = None) -> None:

--- a/buildarr/logging.py
+++ b/buildarr/logging.py
@@ -49,7 +49,12 @@ class StderrFilter(logging.Filter):
 
 def buildarr_log_record_factory(*args, **kwargs) -> logging.LogRecord:
     """
-    Filter for adding Buildarr state information to the logging record.
+    Factory function for adding Buildarr state information to a new log record.
+
+    All parameters are passed to the parent log record factory function.
+
+    Returns:
+        Created log record
     """
 
     record = log_record_factory(*args, **kwargs)

--- a/buildarr/logging.py
+++ b/buildarr/logging.py
@@ -13,24 +13,20 @@
 
 
 """
-Buildarr logging functions and objects.
+Buildarr logging functions.
 """
 
 
 from __future__ import annotations
 
 import logging
-import sys
 
-from typing import TYPE_CHECKING
+from pathlib import Path
+from sys import argv, stderr, stdout
 
 from .state import state
 
-if TYPE_CHECKING:
-    from typing import Any, Mapping, MutableMapping, Tuple
-
-
-__all__ = ["logger", "plugin_logger"]
+log_record_factory = logging.getLogRecordFactory()
 
 
 class StdoutFilter(logging.Filter):
@@ -51,46 +47,15 @@ class StderrFilter(logging.Filter):
         return record.levelno != logging.INFO
 
 
-class BuildarrLoggerAdapter(logging.LoggerAdapter):
+def buildarr_log_record_factory(*args, **kwargs) -> logging.LogRecord:
     """
-    Buildarr logger adapter object.
-
-    Gets wrapped around the standard logger object to provide additional output processing.
-
-    Args:
-        lg (Logger): Standard Python logger object
+    Filter for adding Buildarr state information to the logging record.
     """
 
-    @property
-    def log_level(self) -> str:
-        return logging.getLevelName(self.logger.level)
-
-    def __init__(self, lg: logging.Logger) -> None:
-        super().__init__(lg, {})
-
-    def process(self, msg: str, kwargs: Mapping[str, Any]) -> Tuple[str, MutableMapping[str, Any]]:
-        return (
-            msg,
-            {
-                **kwargs,
-                "extra": {
-                    "plugincontext": (
-                        (
-                            f"buildarr.plugins.{state._current_plugin} "
-                            + (f"{state._current_instance} " if state._current_instance else "")
-                        )
-                        if state._current_plugin
-                        else "buildarr.main "
-                    ),
-                },
-            },
-        )
-
-
-_base_logger = logging.getLogger("buildarr")
-
-logger = BuildarrLoggerAdapter(_base_logger)
-plugin_logger = BuildarrLoggerAdapter(_base_logger)
+    record = log_record_factory(*args, **kwargs)
+    record.plugin = f" <{state._current_plugin}>" if state._current_plugin else ""
+    record.instance = f" ({state._current_instance})" if state._current_instance else ""
+    return record
 
 
 def setup_logger(log_level: str = "DEBUG") -> None:
@@ -102,17 +67,33 @@ def setup_logger(log_level: str = "DEBUG") -> None:
     """
 
     formatter = logging.Formatter(
-        "%(asctime)s %(name)s:%(process)d %(plugincontext)s[%(levelname)s] %(message)s",
+        f"%(asctime)s {Path(argv[0]).name.split('.')[0]}:%(process)d %(name)s [%(levelname)s]"
+        "%(plugin)s%(instance)s %(message)s",
     )
 
-    stdout_handler = logging.StreamHandler(sys.stdout)
+    stdout_handler = logging.StreamHandler(stdout)
     stdout_handler.addFilter(StdoutFilter())
     stdout_handler.setFormatter(formatter)
-    stderr_handler = logging.StreamHandler(sys.stderr)
+    stderr_handler = logging.StreamHandler(stderr)
     stderr_handler.addFilter(StderrFilter())
     stderr_handler.setFormatter(formatter)
 
-    _base_logger.handlers = []
-    _base_logger.addHandler(stdout_handler)
-    _base_logger.addHandler(stderr_handler)
-    _base_logger.setLevel(logging.getLevelName(log_level))
+    logging.setLogRecordFactory(buildarr_log_record_factory)
+
+    root_logger = logging.getLogger()
+    root_logger.handlers = []
+    root_logger.filters = []
+    root_logger.addHandler(stdout_handler)
+    root_logger.addHandler(stderr_handler)
+    root_logger.setLevel(log_level.upper())
+
+
+def get_log_level() -> str:
+    """
+    Get the currently set log level for Buildarr.
+
+    Returns:
+        Log level name
+    """
+
+    return logging.getLevelName(logging.getLogger().level)

--- a/buildarr/manager/__init__.py
+++ b/buildarr/manager/__init__.py
@@ -19,15 +19,18 @@ Buildarr manager interface.
 
 from __future__ import annotations
 
+from logging import getLogger
 from typing import TYPE_CHECKING, Generic
 
-from ..logging import plugin_logger
 from ..plugins import Config, Secrets
 from ..state import state
 
 if TYPE_CHECKING:
     from pathlib import Path
     from typing import Dict, Optional, Set
+
+
+logger = getLogger(__name__)
 
 
 class ManagerPlugin(Generic[Config, Secrets]):
@@ -155,8 +158,8 @@ def load_managers(use_plugins: Optional[Set[str]] = None) -> None:
         if plugin_name not in state.config.__fields_set__:
             continue
         with state._with_context(plugin_name=plugin_name):
-            plugin_logger.debug("Loading plugin manager")
+            logger.debug("Loading plugin manager")
             managers[plugin_name] = plugin.manager()
-            plugin_logger.debug("Finished loading plugin manager")
+            logger.debug("Finished loading plugin manager")
 
     state.managers = managers

--- a/buildarr/plugins/load.py
+++ b/buildarr/plugins/load.py
@@ -19,11 +19,11 @@ Buildarr plugin loading functions.
 
 from __future__ import annotations
 
+from logging import getLogger
 from typing import TYPE_CHECKING
 
 from stevedore.extension import ExtensionManager  # type: ignore[import]
 
-from ..logging import logger
 from ..state import state
 
 if TYPE_CHECKING:
@@ -32,6 +32,9 @@ if TYPE_CHECKING:
     from importlib_metadata import EntryPoint
 
     from . import Plugin
+
+
+logger = getLogger(__name__)
 
 
 def load(namespace: str = "buildarr.plugins") -> None:

--- a/buildarr/plugins/sonarr/api.py
+++ b/buildarr/plugins/sonarr/api.py
@@ -24,12 +24,12 @@ import re
 
 from datetime import datetime, timezone
 from http import HTTPStatus
+from logging import getLogger
 from typing import TYPE_CHECKING
 
 import json5  # type: ignore[import]
 import requests
 
-from buildarr.logging import plugin_logger
 from buildarr.state import state
 
 from .exceptions import SonarrAPIError
@@ -39,6 +39,8 @@ if TYPE_CHECKING:
 
     from .secrets import SonarrSecrets
 
+
+logger = getLogger(__name__)
 
 INITIALIZE_JS_RES_PATTERN = re.compile(r"(?s)^window\.Sonarr = ({.*});$")
 
@@ -56,7 +58,7 @@ def get_initialize_js(host_url: str, api_key: Optional[str] = None) -> Dict[str,
     """
 
     url = f"{host_url}/initialize.js"
-    plugin_logger.debug("GET %s", url)
+    logger.debug("GET %s", url)
     res = requests.get(
         url,
         headers={"X-Api-Key": api_key} if api_key else None,
@@ -66,7 +68,7 @@ def get_initialize_js(host_url: str, api_key: Optional[str] = None) -> Dict[str,
     if not res_match:
         raise RuntimeError(f"No matches for initialize.js parsing: {res.text}")
     res_json = json5.loads(res_match.group(1))
-    plugin_logger.debug("GET %s -> status_code=%i res=%s", url, res.status_code, repr(res_json))
+    logger.debug("GET %s -> status_code=%i res=%s", url, res.status_code, repr(res_json))
     return res_json
 
 
@@ -83,14 +85,14 @@ def api_get(secrets: SonarrSecrets, api_url: str) -> Any:
     """
 
     url = f"{secrets.host_url}/{api_url.lstrip('/')}"
-    plugin_logger.debug("GET %s", url)
+    logger.debug("GET %s", url)
     res = requests.get(
         url,
         headers={"X-Api-Key": secrets.api_key.get_secret_value()},
         timeout=state.config.buildarr.request_timeout,
     )
     res_json = res.json()
-    plugin_logger.debug("GET %s -> status_code=%i res=%s", url, res.status_code, repr(res_json))
+    logger.debug("GET %s -> status_code=%i res=%s", url, res.status_code, repr(res_json))
     if res.status_code != HTTPStatus.OK:
         api_error(method="GET", url=url, response=res)
     return res_json
@@ -110,7 +112,7 @@ def api_post(secrets: SonarrSecrets, api_url: str, req: Any) -> Any:
     """
 
     url = f"{secrets.host_url}/{api_url.lstrip('/')}"
-    plugin_logger.debug("POST %s <- req=%s", url, repr(req))
+    logger.debug("POST %s <- req=%s", url, repr(req))
     headers = {"X-Api-Key": secrets.api_key.get_secret_value()}
     if not state.dry_run:
         res = requests.post(
@@ -122,7 +124,7 @@ def api_post(secrets: SonarrSecrets, api_url: str, req: Any) -> Any:
     else:
         res = _create_dryrun_response("POST", url, content=json.dumps(req))
     res_json = res.json()
-    plugin_logger.debug("POST %s -> status_code=%i res=%s", url, res.status_code, repr(res_json))
+    logger.debug("POST %s -> status_code=%i res=%s", url, res.status_code, repr(res_json))
     if res.status_code != HTTPStatus.CREATED:
         api_error(method="POST", url=url, response=res)
     return res_json
@@ -142,7 +144,7 @@ def api_put(secrets: SonarrSecrets, api_url: str, req: Any) -> Any:
     """
 
     url = f"{secrets.host_url}/{api_url.lstrip('/')}"
-    plugin_logger.debug("PUT %s <- req=%s", url, repr(req))
+    logger.debug("PUT %s <- req=%s", url, repr(req))
     headers = {"X-Api-Key": secrets.api_key.get_secret_value()}
     if not state.dry_run:
         res = requests.put(
@@ -154,7 +156,7 @@ def api_put(secrets: SonarrSecrets, api_url: str, req: Any) -> Any:
     else:
         res = _create_dryrun_response("PUT", url, content=json.dumps(req))
     res_json = res.json()
-    plugin_logger.debug("PUT %s -> status_code=%i res=%s", url, res.status_code, repr(res_json))
+    logger.debug("PUT %s -> status_code=%i res=%s", url, res.status_code, repr(res_json))
     if res.status_code != HTTPStatus.ACCEPTED:
         api_error(method="PUT", url=url, response=res)
     return res_json
@@ -170,7 +172,7 @@ def api_delete(secrets: SonarrSecrets, api_url: str) -> None:
     """
 
     url = f"{secrets.host_url}/{api_url.lstrip('/')}"
-    plugin_logger.debug("DELETE %s", url)
+    logger.debug("DELETE %s", url)
     headers = {"X-Api-Key": secrets.api_key.get_secret_value()}
     res = (
         requests.delete(
@@ -181,7 +183,7 @@ def api_delete(secrets: SonarrSecrets, api_url: str) -> None:
         if not state.dry_run
         else _create_dryrun_response("DELETE", url)
     )
-    plugin_logger.debug("DELETE %s -> status_code=%i", url, res.status_code)
+    logger.debug("DELETE %s -> status_code=%i", url, res.status_code)
     if res.status_code != HTTPStatus.OK:
         api_error(method="DELETE", url=url, response=res, parse_response=False)
 

--- a/buildarr/plugins/sonarr/config/connect.py
+++ b/buildarr/plugins/sonarr/config/connect.py
@@ -20,19 +20,21 @@ Sonarr plugin connect settings configuration.
 from __future__ import annotations
 
 from datetime import datetime
+from logging import getLogger
 from typing import Any, Dict, List, Literal, Mapping, Optional, Set, Tuple, Type, Union
 
 from pydantic import AnyHttpUrl, ConstrainedInt, Field, NameEmail, SecretStr
 from typing_extensions import Annotated, Self
 
 from buildarr.config import RemoteMapEntry
-from buildarr.logging import plugin_logger
 from buildarr.types import BaseEnum, BaseIntEnum, NonEmptyStr, Password, Port
 
 from ..api import api_delete, api_get, api_post, api_put
 from ..secrets import SonarrSecrets
 from .types import SonarrConfigBase, TraktAuthUser
 from .util import trakt_expires_encoder
+
+logger = getLogger(__name__)
 
 
 class OnGrabField(BaseIntEnum):
@@ -377,7 +379,7 @@ class Connection(SonarrConfigBase):
         return False
 
     def _delete_remote(self, tree: str, secrets: SonarrSecrets, connection_id: int) -> None:
-        plugin_logger.info("%s: (...) -> (deleted)", tree)
+        logger.info("%s: (...) -> (deleted)", tree)
         api_delete(secrets, f"/api/v3/notification/{connection_id}")
 
 
@@ -1800,6 +1802,6 @@ class SonarrConnectSettingsConfig(SonarrConfigBase):
                     )
                     changed = True
                 else:
-                    plugin_logger.debug("%s: (...) (unmanaged)", connection_tree)
+                    logger.debug("%s: (...) (unmanaged)", connection_tree)
         #
         return changed

--- a/buildarr/plugins/sonarr/config/download_clients/__init__.py
+++ b/buildarr/plugins/sonarr/config/download_clients/__init__.py
@@ -19,13 +19,13 @@ Sonarr plugin download client settings.
 
 from __future__ import annotations
 
+from logging import getLogger
 from typing import Dict, List, Mapping, Union
 
 from pydantic import Field
 from typing_extensions import Annotated, Self
 
 from buildarr.config import RemoteMapEntry
-from buildarr.logging import plugin_logger
 
 from ...api import api_get, api_put
 from ...secrets import SonarrSecrets
@@ -51,6 +51,8 @@ from .download_clients import (
     VuzeDownloadClient,
 )
 from .remote_path_mappings import SonarrRemotePathMappingsSettingsConfig
+
+logger = getLogger(__name__)
 
 DownloadClientType = Union[
     DownloadstationUsenetDownloadClient,
@@ -258,6 +260,6 @@ class SonarrDownloadClientsSettingsConfig(SonarrConfigBase):
                     )
                     changed = True
                 else:
-                    plugin_logger.debug("%s: (...) (unmanaged)", downloadclient_tree)
+                    logger.debug("%s: (...) (unmanaged)", downloadclient_tree)
         # Return the resource changed status.
         return changed

--- a/buildarr/plugins/sonarr/config/download_clients/download_clients.py
+++ b/buildarr/plugins/sonarr/config/download_clients/download_clients.py
@@ -19,17 +19,19 @@ Sonarr plugin download client definition.
 
 from __future__ import annotations
 
+from logging import getLogger
 from typing import Any, Dict, List, Literal, Mapping, Optional, Set, Tuple, Type
 
 from typing_extensions import Self
 
 from buildarr.config import RemoteMapEntry
-from buildarr.logging import plugin_logger
 from buildarr.types import BaseEnum, NonEmptyStr, Password, Port
 
 from ...api import api_delete, api_post, api_put
 from ...secrets import SonarrSecrets
 from ..types import SonarrConfigBase
+
+logger = getLogger(__name__)
 
 
 class NzbgetPriority(BaseEnum):
@@ -384,7 +386,7 @@ class DownloadClient(SonarrConfigBase):
         secrets: SonarrSecrets,
         downloadclient_id: int,
     ) -> None:
-        plugin_logger.info("%s: (...) -> (deleted)", tree)
+        logger.info("%s: (...) -> (deleted)", tree)
         api_delete(secrets, f"/api/v3/downloadclient/{downloadclient_id}")
 
 

--- a/buildarr/plugins/sonarr/config/download_clients/remote_path_mappings.py
+++ b/buildarr/plugins/sonarr/config/download_clients/remote_path_mappings.py
@@ -19,17 +19,19 @@ Sonarr plugin download client remote path mappings.
 
 from __future__ import annotations
 
+from logging import getLogger
 from typing import Any, Dict, List, Mapping, Tuple
 
 from typing_extensions import Self
 
 from buildarr.config import RemoteMapEntry
-from buildarr.logging import plugin_logger
 from buildarr.types import BaseEnum, NonEmptyStr
 
 from ...api import api_delete, api_get, api_post, api_put
 from ...secrets import SonarrSecrets
 from ..types import SonarrConfigBase
+
+logger = getLogger(__name__)
 
 
 class Ensure(BaseEnum):
@@ -127,7 +129,7 @@ class RemotePathMapping(SonarrConfigBase):
         secrets: SonarrSecrets,
         remotepathmapping_id: int,
     ) -> None:
-        plugin_logger.info("%s: (...) -> (deleted)", tree)
+        logger.info("%s: (...) -> (deleted)", tree)
         api_delete(secrets, f"/api/v3/remotepathmapping/{remotepathmapping_id}")
 
 
@@ -218,15 +220,15 @@ class SonarrRemotePathMappingsSettingsConfig(SonarrConfigBase):
             # and if not, create it.
             if rpm.ensure == Ensure.present:
                 if rpm_tuple in remote_rpms:
-                    plugin_logger.debug("%s: %s (exists)", rpm_tree, repr(rpm))
+                    logger.debug("%s: %s (exists)", rpm_tree, repr(rpm))
                 else:
-                    plugin_logger.info("%s: %s -> (created)", rpm_tree, repr(rpm))
+                    logger.info("%s: %s -> (created)", rpm_tree, repr(rpm))
                     rpm._create_remote(tree=rpm_tree, secrets=secrets)
                     changed = True
             # If the remote path mapping should not exist, check that it does not
             # exist in the remote, and if it does, delete it.
             elif rpm_tuple in remote_rpms:
-                plugin_logger.info("%s: %s -> (deleted)", rpm_tree, repr(rpm))
+                logger.info("%s: %s -> (deleted)", rpm_tree, repr(rpm))
                 rpm._delete_remote(
                     tree=rpm_tree,
                     secrets=secrets,
@@ -234,7 +236,7 @@ class SonarrRemotePathMappingsSettingsConfig(SonarrConfigBase):
                 )
                 changed = True
             else:
-                plugin_logger.debug("%s: %s (does not exist)", rpm_tree, repr(rpm))
+                logger.debug("%s: %s (does not exist)", rpm_tree, repr(rpm))
         # Handle unmanaged remote path mappings.
         # If `delete_unmanaged` is `True`, automatically delete them.
         j = -1
@@ -243,7 +245,7 @@ class SonarrRemotePathMappingsSettingsConfig(SonarrConfigBase):
             if rpm_tuple not in local_rpms:
                 rpm_tree = f"{tree}.definitions[{j}]"
                 if self.delete_unmanaged:
-                    plugin_logger.info("%s: %s -> (deleted)", rpm_tree, repr(rpm))
+                    logger.info("%s: %s -> (deleted)", rpm_tree, repr(rpm))
                     rpm._delete_remote(
                         tree=rpm_tree,
                         secrets=secrets,
@@ -251,7 +253,7 @@ class SonarrRemotePathMappingsSettingsConfig(SonarrConfigBase):
                     )
                     changed = True
                 else:
-                    plugin_logger.debug("%s: %s (unmanaged)", rpm_tree, repr(rpm))
+                    logger.debug("%s: %s (unmanaged)", rpm_tree, repr(rpm))
                 j -= 1
         # Return changed status.
         return changed

--- a/buildarr/plugins/sonarr/config/import_lists.py
+++ b/buildarr/plugins/sonarr/config/import_lists.py
@@ -22,6 +22,7 @@ from __future__ import annotations
 import re
 
 from datetime import datetime
+from logging import getLogger
 from typing import (
     TYPE_CHECKING,
     Any,
@@ -42,7 +43,6 @@ from pydantic import AnyHttpUrl, ConstrainedStr, Field, PositiveInt, validator
 from typing_extensions import Annotated, Self
 
 from buildarr.config import RemoteMapEntry
-from buildarr.logging import plugin_logger
 from buildarr.state import state
 from buildarr.types import BaseEnum, InstanceName, NonEmptyStr, Password
 
@@ -56,6 +56,9 @@ if TYPE_CHECKING:
     from typing import Collection
 
     from ..config import SonarrInstanceConfig
+
+
+logger = getLogger(__name__)
 
 
 class YearRange(ConstrainedStr):
@@ -433,7 +436,7 @@ class ImportList(SonarrConfigBase):
             secrets (SonarrSecrets): Secrets metadata for the remote instance.
             importlist_id (int): ID associated with this import list on the remote instance.
         """
-        plugin_logger.info("%s: (...) -> (deleted)", tree)
+        logger.info("%s: (...) -> (deleted)", tree)
         api_delete(secrets, f"/api/v3/importlist/{importlist_id}")
 
 
@@ -1009,7 +1012,7 @@ class SonarrImportList(ProgramImportList):
                     resolved_source_resources.add(resource_names[resource])
                 except KeyError:
                     if ignore_nonexistent_ids:
-                        plugin_logger.warning(
+                        logger.warning(
                             (
                                 "Source %s ID %i referenced by remote Sonarr instance "
                                 "not found on target instance '%s', removing"
@@ -1363,6 +1366,6 @@ class SonarrImportListsSettingsConfig(SonarrConfigBase):
                     )
                     changed = True
                 else:
-                    plugin_logger.debug("%s: (...) (unmanaged)", importlist_tree)
+                    logger.debug("%s: (...) (unmanaged)", importlist_tree)
         # We're done!
         return changed

--- a/buildarr/plugins/sonarr/config/indexers.py
+++ b/buildarr/plugins/sonarr/config/indexers.py
@@ -19,18 +19,20 @@ Sonarr plugin indexers settings configuration.
 
 from __future__ import annotations
 
+from logging import getLogger
 from typing import Any, Dict, List, Literal, Mapping, Optional, Set, Tuple, Type, Union
 
 from pydantic import AnyHttpUrl, Field, PositiveInt
 from typing_extensions import Annotated, Self
 
 from buildarr.config import RemoteMapEntry
-from buildarr.logging import plugin_logger
 from buildarr.types import BaseEnum, BaseIntEnum, NonEmptyStr, Password, RssUrl
 
 from ..api import api_delete, api_get, api_post, api_put
 from ..secrets import SonarrSecrets
 from .types import SonarrConfigBase
+
+logger = getLogger(__name__)
 
 
 class NabCategory(BaseIntEnum):
@@ -250,7 +252,7 @@ class Indexer(SonarrConfigBase):
         return False
 
     def _delete_remote(self, tree: str, secrets: SonarrSecrets, indexer_id: int) -> None:
-        plugin_logger.info("%s: (...) -> (deleted)", tree)
+        logger.info("%s: (...) -> (deleted)", tree)
         api_delete(secrets, f"/api/v3/indexer/{indexer_id}")
 
 
@@ -1121,6 +1123,6 @@ class SonarrIndexersSettingsConfig(SonarrConfigBase):
                     )
                     changed = True
                 else:
-                    plugin_logger.debug("%s: (...) (unmanaged)", indexer_tree)
+                    logger.debug("%s: (...) (unmanaged)", indexer_tree)
         #
         return changed

--- a/buildarr/plugins/sonarr/config/media_management.py
+++ b/buildarr/plugins/sonarr/config/media_management.py
@@ -19,18 +19,20 @@ Sonarr plugin media management settings configuration.
 
 from __future__ import annotations
 
+from logging import getLogger
 from typing import Any, Dict, List, Optional, Set
 
 from pydantic import Field
 from typing_extensions import Self
 
 from buildarr.config import RemoteMapEntry
-from buildarr.logging import plugin_logger
 from buildarr.types import BaseEnum, NonEmptyStr
 
 from ..api import api_delete, api_get, api_post, api_put
 from ..secrets import SonarrSecrets
 from .types import SonarrConfigBase
+
+logger = getLogger(__name__)
 
 
 class MultiEpisodeStyle(BaseEnum):
@@ -609,15 +611,15 @@ class SonarrMediaManagementSettingsConfig(SonarrConfigBase):
             i = -1
             for root_folder, root_folder_id in current_root_folders.items():
                 if root_folder not in expected_root_folders:
-                    plugin_logger.info("%s[%i]: %s -> (deleted)", tree, i, repr(str(root_folder)))
+                    logger.info("%s[%i]: %s -> (deleted)", tree, i, repr(str(root_folder)))
                     api_delete(secrets, f"/api/v3/rootfolder/{root_folder_id}")
                     changed = True
                     i -= 1
         for i, root_folder in enumerate(self.root_folders):
             if root_folder in current_root_folders:
-                plugin_logger.debug("%s[%i]: %s (exists)", tree, i, repr(str(root_folder)))
+                logger.debug("%s[%i]: %s (exists)", tree, i, repr(str(root_folder)))
             else:
-                plugin_logger.info("%s[%i]: %s -> (created)", tree, i, repr(str(root_folder)))
+                logger.info("%s[%i]: %s -> (created)", tree, i, repr(str(root_folder)))
                 api_post(secrets, "/api/v3/rootfolder", {"path": str(root_folder)})
                 changed = True
         return changed

--- a/buildarr/plugins/sonarr/config/profiles/delay.py
+++ b/buildarr/plugins/sonarr/config/profiles/delay.py
@@ -19,18 +19,20 @@ Sonarr plugin delay profile configuration.
 
 from __future__ import annotations
 
+from logging import getLogger
 from typing import Any, Dict, List, Mapping, Set
 
 from pydantic import Field
 from typing_extensions import Self
 
 from buildarr.config import RemoteMapEntry
-from buildarr.logging import plugin_logger
 from buildarr.types import BaseEnum, NonEmptyStr
 
 from ...api import api_delete, api_get, api_post, api_put
 from ...secrets import SonarrSecrets
 from ..types import SonarrConfigBase
+
+logger = getLogger(__name__)
 
 
 class PreferredProtocol(BaseEnum):
@@ -263,7 +265,7 @@ class DelayProfile(SonarrConfigBase):
         secrets: SonarrSecrets,
         profile_id: int,
     ) -> None:
-        plugin_logger.info("%s: (...) -> (deleted)", tree)
+        logger.info("%s: (...) -> (deleted)", tree)
         api_delete(secrets, f"/api/v3/delayprofile/{profile_id}")
 
 
@@ -324,11 +326,11 @@ class SonarrDelayProfilesSettingsConfig(SonarrConfigBase):
         check_unmanaged: bool = False,
     ) -> bool:
         if not self.delete_unmanaged and "definitions" not in self.__fields_set__:
-            # TODO: printcurrent delay profile structure
+            # TODO: Print current delay profile structure.
             if remote.definitions:
-                plugin_logger.debug("%s.definitions: [...] (unmanaged)", tree)
+                logger.debug("%s.definitions: [...] (unmanaged)", tree)
             else:
-                plugin_logger.debug("%s.definitions: [] (unmanaged)", tree)
+                logger.debug("%s.definitions: [] (unmanaged)", tree)
             return False
         #
         changed = False

--- a/buildarr/plugins/sonarr/config/profiles/language.py
+++ b/buildarr/plugins/sonarr/config/profiles/language.py
@@ -19,18 +19,20 @@ Sonarr plugin language profile configuration.
 
 from __future__ import annotations
 
+from logging import getLogger
 from typing import Any, Dict, List, Mapping, Optional, Sequence, Set
 
 from pydantic import Field, validator
 from typing_extensions import Annotated, Self
 
 from buildarr.config import RemoteMapEntry
-from buildarr.logging import plugin_logger
 from buildarr.types import BaseEnum
 
 from ...api import api_delete, api_get, api_post, api_put
 from ...secrets import SonarrSecrets
 from ..types import SonarrConfigBase
+
+logger = getLogger(__name__)
 
 
 class Language(BaseEnum):
@@ -304,7 +306,7 @@ class LanguageProfile(SonarrConfigBase):
         return False
 
     def _delete_remote(self, tree: str, secrets: SonarrSecrets, profile_id: int) -> None:
-        plugin_logger.info("%s: (...) -> (deleted)", tree)
+        logger.info("%s: (...) -> (deleted)", tree)
         api_delete(secrets, f"/api/v3/languageprofile/{profile_id}")
 
 
@@ -404,6 +406,6 @@ class SonarrLanguageProfilesSettingsConfig(SonarrConfigBase):
                     )
                     changed = True
                 else:
-                    plugin_logger.debug("%s: (...) (unmanaged)", profile_tree)
+                    logger.debug("%s: (...) (unmanaged)", profile_tree)
         #
         return changed

--- a/buildarr/plugins/sonarr/config/profiles/quality.py
+++ b/buildarr/plugins/sonarr/config/profiles/quality.py
@@ -19,18 +19,20 @@ Sonarr plugin quality profile configuration.
 
 from __future__ import annotations
 
+from logging import getLogger
 from typing import Any, Dict, List, Mapping, Optional, Sequence, Set, Union
 
 from pydantic import Field, validator
 from typing_extensions import Annotated, Self
 
 from buildarr.config import RemoteMapEntry
-from buildarr.logging import plugin_logger
 from buildarr.types import NonEmptyStr
 
 from ...api import api_delete, api_get, api_post, api_put
 from ...secrets import SonarrSecrets
 from ..types import SonarrConfigBase
+
+logger = getLogger(__name__)
 
 
 class QualityGroup(SonarrConfigBase):
@@ -324,7 +326,7 @@ class QualityProfile(SonarrConfigBase):
         return False
 
     def _delete_remote(self, tree: str, secrets: SonarrSecrets, profile_id: int) -> None:
-        plugin_logger.info("%s: (...) -> (deleted)", tree)
+        logger.info("%s: (...) -> (deleted)", tree)
         api_delete(secrets, f"/api/v3/qualityprofile/{profile_id}")
 
 
@@ -415,7 +417,7 @@ class SonarrQualityProfilesSettingsConfig(SonarrConfigBase):
                     )
                     changed = True
                 else:
-                    plugin_logger.debug("%s: (...) (unmanaged)", profile_tree)
+                    logger.debug("%s: (...) (unmanaged)", profile_tree)
         #
         return changed
 

--- a/buildarr/plugins/sonarr/config/profiles/release.py
+++ b/buildarr/plugins/sonarr/config/profiles/release.py
@@ -21,6 +21,7 @@ from __future__ import annotations
 
 import json
 
+from logging import getLogger
 from pathlib import Path
 from typing import Any, Dict, Iterable, List, Mapping, Optional, Set, cast
 
@@ -28,12 +29,13 @@ from pydantic import validator
 from typing_extensions import Self
 
 from buildarr.config import ConfigTrashIDNotFoundError, RemoteMapEntry
-from buildarr.logging import plugin_logger
 from buildarr.types import NonEmptyStr, TrashID
 
 from ...api import api_delete, api_get, api_post, api_put
 from ...secrets import SonarrSecrets
 from ..types import SonarrConfigBase
+
+logger = getLogger(__name__)
 
 
 class TrashFilter(SonarrConfigBase):
@@ -376,7 +378,7 @@ class ReleaseProfile(SonarrConfigBase):
         return False
 
     def _delete_remote(self, tree: str, secrets: SonarrSecrets, profile_id: int) -> None:
-        plugin_logger.info("%s: (...) -> (deleted)", tree)
+        logger.info("%s: (...) -> (deleted)", tree)
         api_delete(secrets, f"/api/v3/releaseprofile/{profile_id}")
 
     # Tell Pydantic to validate in-place assignments of attributes.
@@ -486,6 +488,6 @@ class SonarrReleaseProfilesSettingsConfig(SonarrConfigBase):
                     )
                     changed = True
                 else:
-                    plugin_logger.debug("%s: (...) (unmanaged)", profile_tree)
+                    logger.debug("%s: (...) (unmanaged)", profile_tree)
         #
         return changed

--- a/buildarr/plugins/sonarr/config/tags.py
+++ b/buildarr/plugins/sonarr/config/tags.py
@@ -19,16 +19,18 @@ Sonarr plugin tags settings configuration.
 
 from __future__ import annotations
 
+from logging import getLogger
 from typing import Dict, List
 
 from typing_extensions import Self
 
-from buildarr.logging import plugin_logger
 from buildarr.types import NonEmptyStr
 
 from ..api import api_get, api_post
 from ..secrets import SonarrSecrets
 from .types import SonarrConfigBase
+
+logger = getLogger(__name__)
 
 
 class SonarrTagsSettingsConfig(SonarrConfigBase):
@@ -90,9 +92,9 @@ class SonarrTagsSettingsConfig(SonarrConfigBase):
         if self.definitions:
             for i, tag in enumerate(self.definitions):
                 if tag in current_tags:
-                    plugin_logger.debug("%s.definitions[%i]: %s (exists)", tree, i, repr(tag))
+                    logger.debug("%s.definitions[%i]: %s (exists)", tree, i, repr(tag))
                 else:
-                    plugin_logger.info("%s.definitions[%i]: %s -> (created)", tree, i, repr(tag))
+                    logger.info("%s.definitions[%i]: %s -> (created)", tree, i, repr(tag))
                     api_post(secrets, "/api/v3/tag", {"label": tag})
                     changed = True
         return changed

--- a/buildarr/secrets/load.py
+++ b/buildarr/secrets/load.py
@@ -19,11 +19,11 @@ Buildarr secrets metadata loading function.
 
 from __future__ import annotations
 
+from logging import getLogger
 from typing import TYPE_CHECKING, Dict
 
 from pydantic import create_model
 
-from ..logging import logger
 from ..state import state
 from ..types import NonEmptyStr
 from .base import SecretsBase
@@ -31,6 +31,8 @@ from .base import SecretsBase
 if TYPE_CHECKING:
     from pathlib import Path
     from typing import Optional, Set
+
+logger = getLogger(__name__)
 
 
 def load_secrets(path: Path, use_plugins: Optional[Set[str]] = None) -> bool:

--- a/buildarr/trash.py
+++ b/buildarr/trash.py
@@ -20,13 +20,13 @@ Buildarr TRaSH-Guides metadata functions.
 from __future__ import annotations
 
 from collections import defaultdict
+from logging import getLogger
 from pathlib import Path
 from shutil import move
 from typing import TYPE_CHECKING
 from urllib.request import urlretrieve
 from zipfile import ZipFile
 
-from .logging import logger, plugin_logger
 from .state import state
 from .util import create_temp_dir
 
@@ -34,6 +34,9 @@ if TYPE_CHECKING:
     from typing import DefaultDict, Dict
 
     from .config import ConfigPlugin
+
+
+logger = getLogger(__name__)
 
 
 def trash_metadata_used() -> bool:
@@ -109,14 +112,14 @@ def render_trash_metadata(trash_metadata_dir: Path) -> None:
         instance_config = state.instance_configs[plugin_name][instance_name]
         with state._with_context(plugin_name=plugin_name, instance_name=instance_name):
             if manager.uses_trash_metadata(instance_config):
-                plugin_logger.debug("Rendering TRaSH-Guides metadata")
+                logger.debug("Rendering TRaSH-Guides metadata")
                 instance_configs[plugin_name][instance_name] = manager.render_trash_metadata(
                     instance_config,
                     trash_metadata_dir,
                 )
-                plugin_logger.debug("Finished rendering TRaSH-Guides metadata")
+                logger.debug("Finished rendering TRaSH-Guides metadata")
             else:
-                plugin_logger.debug("Skipping rendering TRaSH-Guides metadata (not used)")
+                logger.debug("Skipping rendering TRaSH-Guides metadata (not used)")
                 instance_configs[plugin_name][instance_name] = instance_config
 
     state.instance_configs = instance_configs

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -32,7 +32,7 @@ Usage: buildarr [OPTIONS] COMMAND [ARGS]...
   instances.
 
 Options:
-  -l, --log-level [CRITICAL|ERROR|WARNING|INFO|DEBUG|NOTSET]
+  -l, --log-level [ERROR|WARNING|INFO|DEBUG]
                                   Buildarr logging system log level. Can also
                                   be set using the `$BUILDARR_LOG_LEVEL'
                                   environment variable.  [default: INFO]


### PR DESCRIPTION
* Configure the root logger directly instead of creating common logger objects used by all files
    * Debug logging from other modules/packages used by Buildarr (e.g. `urllib`) will now be handled, formatted correctly, and output to the same streams as regular Buildarr logs
* Use a custom log record factory to insert Buildarr-specific metadata into logging records when they are created
    * This allows plugin and instance-specific logs to have their special formatting without using a dedicated logger object
    * Files now only use a single standard `logging.Logger` object to output all their logs, removing the need to worry about which logger object to use
* Change all files create their own logger objects using `logger.getLogger(__name__)` 
    * This allows real module names to be output in logs, instead of an approximation constructed by Buildarr
    * Plugins now use the standard library logging functions, reducing the coupling between Buildarr and its plugins, and moving the `buildarr.logging` module out of the plugin API (and into the internal namespace)
* Reduce the available log level types to only the ones that should be used in Buildarr: `DEBUG`, `INFO`, `WARNING` and `ERROR`
* Ensure that the `--log-level` argument is case-insensitive