### PR TITLE
Improve and add missing docs for new features

### DIFF
--- a/buildarr/config/buildarr.py
+++ b/buildarr/config/buildarr.py
@@ -118,6 +118,9 @@ class BuildarrConfig(ConfigBase):
     secrets_file_path: Path = Path("secrets.json")
     """
     Path to store the Buildarr instance secrets file.
+
+    *New in version 0.4.0*: This configuration option can now be overridden
+    using the `--secrets-file` command line argument.
     """
 
     request_timeout: PositiveFloat = 30  # seconds
@@ -126,7 +129,7 @@ class BuildarrConfig(ConfigBase):
 
     If the timeout is reached, an error will occur and Buildarr will stop the update process.
 
-    *Added in version 0.3.0.*
+    *New in version 0.3.0.*
     """
 
     trash_metadata_download_url: AnyHttpUrl = (

--- a/buildarr/plugins/sonarr/config/import_lists.py
+++ b/buildarr/plugins/sonarr/config/import_lists.py
@@ -660,7 +660,7 @@ class SonarrImportList(ProgramImportList):
     The name of the Sonarr instance within Buildarr, if linking this Sonarr instance
     with another Buildarr-defined Sonarr instance.
 
-    *Added in version 0.3.0.*
+    *New in version 0.3.0.*
     """
 
     full_url: AnyHttpUrl
@@ -687,8 +687,8 @@ class SonarrImportList(ProgramImportList):
     link to a Buildarr-defined Sonarr instance.
     If linking to a Sonarr instance outside Buildarr, IDs must be used.
 
-    *Changed in version 0.3.0: Renamed from `source_quality_profile_ids`
-    (which is still valid as an alias), and add support for quality profile names.*
+    *Changed in version 0.3.0*: Renamed from `source_quality_profile_ids`
+    (which is still valid as an alias), and added support for quality profile names.
     """
 
     source_language_profiles: Set[Union[PositiveInt, NonEmptyStr]] = Field(
@@ -702,8 +702,8 @@ class SonarrImportList(ProgramImportList):
     link to a Buildarr-defined Sonarr instance.
     If linking to a Sonarr instance outside Buildarr, IDs must be used.
 
-    *Changed in version 0.3.0: Renamed from `source_language_profile_ids`
-    (which is still valid as an alias), and add support for language profile names.*
+    *Changed in version 0.3.0*: Renamed from `source_language_profile_ids`
+    (which is still valid as an alias), and added support for language profile names.
     """
 
     source_tags: Set[Union[PositiveInt, NonEmptyStr]] = Field(set(), alias="source_tag_ids")
@@ -714,8 +714,8 @@ class SonarrImportList(ProgramImportList):
     link to a Buildarr-defined Sonarr instance.
     If linking to a Sonarr instance outside Buildarr, IDs must be used.
 
-    *Changed in version 0.3.0: Renamed from `source_tag_ids`
-    (which is still valid as an alias), and add support for tag names.*
+    *Changed in version 0.3.0*: Renamed from `source_tag_ids`
+    (which is still valid as an alias), and added support for tag names.
     """
 
     _implementation_name: str = "Sonarr"

--- a/buildarr/plugins/sonarr/config/media_management.py
+++ b/buildarr/plugins/sonarr/config/media_management.py
@@ -451,7 +451,7 @@ class SonarrMediaManagementSettingsConfig(SonarrConfigBase):
     as Sonarr might remove imported media from its database
     when root folder definitions are deleted.
 
-    *Added in version 0.1.2.*
+    *New in version 0.1.2.*
     """
 
     _naming_remote_map: List[RemoteMapEntry] = [


### PR DESCRIPTION
* Change all usage of `Added in` to `New in` to be consistent with how Python documents new features
* Make new feature notes only partially italicised
* Added a note for the new `--secrets-file` command line argument in the `buildarr.secrets_file_path` configuration attribute docs