### PR TITLE
Evaluate local paths relative to the config file

### DIFF
--- a/buildarr/config/buildarr.py
+++ b/buildarr/config/buildarr.py
@@ -25,7 +25,7 @@ from typing import Set
 
 from pydantic import AnyHttpUrl, PositiveFloat
 
-from ..types import DayOfWeek
+from ..types import DayOfWeek, LocalPath
 from .base import ConfigBase
 
 
@@ -114,13 +114,21 @@ class BuildarrConfig(ConfigBase):
     This configuration option can be overridden using the `--update-times` command line argument.
     """
 
-    # TODO: Make this relative to the configuration file, not local to the current directory.
-    secrets_file_path: Path = Path("secrets.json")
+    secrets_file_path: LocalPath = LocalPath("secrets.json")
     """
     Path to store the Buildarr instance secrets file.
 
+    By default, this will create a file called `secrets.json` in the same folder
+    the first loaded configuration file is located.
+
     *New in version 0.4.0*: This configuration option can now be overridden
     using the `--secrets-file` command line argument.
+
+    *Changed in version 0.4.0*: Relative file paths are now evaluated relative
+    to the directory the configuration file that defined the attribute is located,
+    not the current working directory of the Buildarr process. If the attribute
+    is undefined, the secrets file will be created in the directory the
+    originally loaded configuration file is located.
     """
 
     request_timeout: PositiveFloat = 30  # seconds

--- a/buildarr/state.py
+++ b/buildarr/state.py
@@ -24,10 +24,10 @@ import os
 from collections import defaultdict
 from contextlib import contextmanager
 from distutils.util import strtobool
+from pathlib import Path
 from typing import TYPE_CHECKING, Tuple
 
 if TYPE_CHECKING:
-    from pathlib import Path
     from typing import DefaultDict, FrozenSet, Generator, Mapping, Optional, Sequence, Set
 
     from .config import ConfigPlugin, ConfigType
@@ -106,6 +106,13 @@ class State:
     Currently loaded instance secrets.
     """
 
+    _current_dir: Path = Path.cwd()
+    """
+    Current working directory for relative path resolution.
+
+    This state attribute is internal, and shouldn't be accessed by plugins.
+    """
+
     _current_plugin: str
     """
     The plugin being processed in the current context.
@@ -163,6 +170,21 @@ class State:
         self._current_instance = None  # type: ignore[assignment]
         self._instance_dependencies = defaultdict(set)  # type: ignore[assignment]
         self._execution_order = None  # type: ignore[assignment]
+
+    @contextmanager
+    def _with_current_dir(self, current_dir: Path) -> Generator[None, None, None]:
+        """
+        Set the current directory context within a code block.
+
+        This state function is internal, and shouldn't be used by plugins.
+
+        Args:
+            current_dir (Path): Path to use as the current directory.
+        """
+        old_current_dir = self._current_dir
+        self._current_dir = current_dir
+        yield
+        self._current_dir = old_current_dir
 
     @contextmanager
     def _with_context(

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -38,7 +38,17 @@ Nested inclusion is allowed (included files can include other files). All the lo
 
 If any configuration attributes in files overlap, the last-read value will take precedence. Note that any overlapping attributes that are lists will be overwritten, rather than combined.
 
-Overly complicated include structures should be avoided, to ensure legibility of the configuration.
+!!! note
+
+    In order to evaluate per-file relative paths, configuration files will be parsed and validated individually first, and then validated again as a combined configuration structure.
+
+    Take care to ensure that the individual configuration files do not depend on each other being combined to become valid.
+
+    Instances that depend on other instances via e.g. `instance_name` are not subject to this limitation, and can freely be defined in separate files.
+
+    To make troubleshooting easier and to ensure readability, overly complicated include structures in configuration files should be avoided.
+
+Here is an example of a global `buildarr.yml` configuration file including two Sonarr instance configuration from separate files in the same directory as `buildarr.yml`:
 
 `buildarr.yml`:
 ```yaml

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -11,9 +11,14 @@ The following commands are available for Buildarr:
 * `buildarr <plugin-name> <command...>` - Ad-hoc commands defined by any loaded plugins
 
 !!! note
-    Every time Buildarr performs an update run, a metadata file called `secrets.json` is generated to store secrets information for every configured instance in the current directory. Ensure that you are running Buildarr in a folder that is not world-viewable, to avoid exposing secrets.
 
-    If you are using the Docker image, ensure that the folder mounted as `/config` into the container has appropriately secure permissions.
+    Every time Buildarr performs an update run, a file named `secrets.json` is created in the folder the configuration file is located. This file caches secrets metadata for every configured instance.
+
+    Ensure that the Buildarr configuration is located in a folder that is not world-viewable, to avoid exposing secrets.
+
+    If you are using Docker, ensure that the folder mounted as `/config` into the container has appropriately secure permissions.
+
+    The location of `secrets.json` can be configured using the `--secrets-file` command line option, or the [`buildarr.secrets_file_path` attribute](configuration.md#buildarr.config.buildarr.BuildarrConfig.secrets_file_path) in the configuration file.
 
 The verbosity of Buildarr logging output can be adjusted using the `--log-level` option.
 This option can also be set using the `$BUILDARR_LOG_LEVEL` environment variable.


### PR DESCRIPTION
Reimplement configuration parsing so that intermediate configuration files are validated by Pydantic once, before being turned back into dictionaries, merged into one structure, and validated again by Pydantic to get the final configuration object.

This has some implications for how multiple configuration files are handled, and the documentation has been updated to reflect this. Realistically, however, the side effects from this are expected to be minimal.

This allows a new `LocalPath` attribute type to be added, which is evaluated when these intermediate configuration files are loaded, and parsed to be absolute paths relative to the directory containing the actual configuration file the attribute was loaded from.

If a `LocalPath` type attribute has a default value and was not defined in the configuration, the directory that contains the originally parsed configuration is used to turn it into an absolute path (instead of the current working directory for the Buildarr process.)

The following attributes have been changed to type `LocalPath`:
* `buildarr.secrets_file_path`