### PR TITLE
Add temporary ignore for `watchdog.Observer` type hint

### DIFF
--- a/buildarr/cli/daemon.py
+++ b/buildarr/cli/daemon.py
@@ -211,7 +211,9 @@ class Daemon:
         # and another initial run is performed.
         if self.watch_config:
             logger.info("Setting up config file monitoring")
-            self.observer = Observer()
+            # TODO: Remove ignore when the following issue is fixed.
+            # https://github.com/gorakhargosh/watchdog/issues/982
+            self.observer = Observer()  # type: ignore[assignment]
             config_dirs: Dict[Path, Set[str]] = {}
             for config_file in state.config_files:
                 if config_file.parent not in config_dirs:


### PR DESCRIPTION
A bug in the type hint for the `watchdog.Observer` base class makes Mypy fail.

This error does not show on the pre-commit hooks because not all the packages are installed into that environment.

Add an error-specific ignore comment to the offending line, and add a `TODO` to document the tracking issue in the `watchdog` repository.

https://github.com/gorakhargosh/watchdog/issues/982

