### PR TITLE
Add the `buildarr compose` command

### DIFF
--- a/buildarr/cli/compose.py
+++ b/buildarr/cli/compose.py
@@ -1,0 +1,220 @@
+# Copyright (C) 2023 Callum Dickinson
+#
+# Buildarr is free software: you can redistribute it and/or modify it under the terms of the
+# GNU General Public License as published by the Free Software Foundation,
+# either version 3 of the License, or (at your option) any later version.
+#
+# Buildarr is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY;
+# without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+# See the GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License along with Buildarr.
+# If not, see <https://www.gnu.org/licenses/>.
+
+
+"""
+`buildarr compose` CLI command.
+"""
+
+
+from __future__ import annotations
+
+from logging import getLogger
+from pathlib import Path
+from textwrap import indent
+from typing import TYPE_CHECKING
+
+import click
+import yaml
+
+from importlib_metadata import version as package_version
+
+from ..config import load_config, load_instance_configs, resolve_instance_dependencies
+from ..logging import get_log_level
+from ..manager import load_managers
+from ..state import state
+from ..util import get_resolved_path
+from . import cli
+from .exceptions import ComposeNoPluginsDefinedError, ComposeNotSupportedError
+
+if TYPE_CHECKING:
+    from typing import Any, Dict, Set
+
+
+logger = getLogger(__name__)
+
+
+@cli.command(
+    help=(
+        "Test a Buildarr configuration file for correctness.\n\n"
+        "This loads the configuration file and performs a number of checks on it. "
+        "If all tests pass, the file is pretty much guaranteed to work properly "
+        "in a Buildarr run, incorrect values for a remote instance notwithstanding.\n\n"
+        "To validate the configuration against remote instances without modifying them, "
+        "use `buildarr run --dry-run'.\n\n"
+        "If CONFIG-PATH is not defined, use `buildarr.yml' from the current directory."
+    ),
+)
+@click.argument(
+    "config_path",
+    metavar="[CONFIG-PATH]",
+    type=click.Path(
+        exists=True,
+        file_okay=True,
+        dir_okay=False,
+        readable=True,
+        path_type=Path,
+    ),
+    default=Path.cwd() / "buildarr.yml",
+    # Get absolute path and resolve symlinks in ad-hoc runs.
+    callback=lambda ctx, params, path: get_resolved_path(path),
+)
+@click.option(
+    "-p",
+    "--plugin",
+    "use_plugins",
+    metavar="PLUGIN",
+    type=str,
+    callback=lambda ctx, params, plugins: set(plugins),
+    multiple=True,
+    help=(
+        "Use only the specified Buildarr plugin. Default is to use all installed plugins. "
+        "(can be defined multiple times)"
+    ),
+)
+@click.option(
+    "-V",
+    "--compose-version",
+    "compose_version",
+    metavar="VERSION",
+    type=str,
+    default="3.7",
+    help="Version of the generated Docker Compose file. Default is `3.7'.",
+)
+@click.option(
+    "-r",
+    "--restart",
+    "compose_restart",
+    type=click.Choice(["always", "unless-stopped", "on-failure", "no"], case_sensitive=False),
+    default="always",
+    help="Restart policy for services. Default is `always'.",
+)
+def compose(
+    config_path: Path,
+    use_plugins: Set[str],
+    compose_version: str,
+    compose_restart: str,
+) -> None:
+    """
+    `buildarr compose` main routine.
+
+    Args:
+        config_path (Path): Configuration file to load.
+        use_plugins (Set[str]): Plugins to load. If empty, use all plugins.
+    """
+
+    logger.debug(
+        "Buildarr version %s (log level: %s)",
+        package_version("buildarr"),
+        get_log_level(),
+    )
+    logger.debug(
+        "Plugins loaded: %s",
+        ", ".join(sorted(state.plugins.keys())) if state.plugins else "(no plugins found)",
+    )
+    logger.debug(
+        "Creating Docker Compose file from configuration file: %s",
+        str(config_path),
+    )
+
+    logger.debug("Loading configuration file '%s'", config_path)
+    load_config(path=config_path, use_plugins=use_plugins)
+    logger.debug("Finished loading configuration file")
+    logger.debug("Buildarr configuration:")
+    for config_line in state.config.yaml(exclude_unset=True).splitlines():
+        logger.debug(indent(config_line, "  "))
+
+    logger.debug("Loading plugin managers")
+    load_managers(use_plugins)
+    logger.debug("Finished loading plugin managers")
+    logger.debug("Managers loaded for the following plugins:")
+    for plugin_name in state.managers.keys():
+        logger.debug("  - %s", plugin_name)
+
+    logger.debug("Loading instance configurations")
+    load_instance_configs(use_plugins)
+    logger.debug("Finished loading instance configurations")
+    for plugin_name, instance_configs in state.instance_configs.items():
+        for instance_name, instance_config in instance_configs.items():
+            with state._with_context(plugin_name=plugin_name, instance_name=instance_name):
+                logger.debug("Instance configuration:")
+                for config_line in instance_config.yaml(exclude_unset=True).splitlines():
+                    logger.debug(indent(config_line, "  "))
+
+    if not state.active_plugins:
+        raise ComposeNoPluginsDefinedError("No loaded plugins configured in Buildarr")
+
+    logger.debug("Resolving instance dependencies")
+    resolve_instance_dependencies()
+    logger.debug("Finished resolving instance dependencies")
+    logger.debug("Execution order:")
+    for i, (plugin_name, instance_name) in enumerate(state._execution_order, 1):
+        logger.debug("  %i. %s.instances[%s]", i, plugin_name, repr(instance_name))
+
+    compose_obj: Dict[str, Any] = {"version": compose_version}
+    volumes: Set[str] = set()
+
+    for plugin_name, instance_name in state._execution_order:
+        manager = state.managers[plugin_name]
+        instance_config = state.instance_configs[plugin_name][instance_name]
+        with state._with_context(plugin_name=plugin_name, instance_name=instance_name):
+            service_name = f"{plugin_name}_{instance_name}"
+            logger.debug("Generating Docker Compose configuration for service '%s'", service_name)
+            try:
+                logger.debug("Generating service-specific configuration")
+                compose_obj[service_name] = {
+                    **manager.to_compose_service(
+                        instance_config=instance_config,
+                        compose_version=compose_version,
+                        service_name=service_name,
+                    ),
+                    "restart": compose_restart,
+                }
+                logger.debug("Finished generating service-specific configuration")
+            except NotImplementedError:
+                raise ComposeNotSupportedError(
+                    f"Plugin '{plugin_name}' does not support Docker Compose "
+                    "service generation from instance configurations",
+                ) from None
+            if (plugin_name, instance_name) in state._instance_dependencies:
+                depends_on: Set[str] = set()
+                logger.debug("Generating service dependencies")
+                for (target_plugin, target_instance) in state._instance_dependencies[
+                    (plugin_name, instance_name)
+                ]:
+                    target_service = f"{target_plugin}_{target_instance}"
+                    logger.debug("Adding dependency to service '%s'", target_service)
+                    depends_on.add(target_service)
+                compose_obj[service_name]["depends_on"] = list(depends_on)
+                logger.debug("Finished generating service dependencies")
+            for volume_name in compose_obj[service_name].get("volumes", {}).keys():
+                if "/" not in volume_name and "\\" not in volume_name:
+                    logger.debug(
+                        "Adding named volume '%s' to the list of internal volumes",
+                        volume_name,
+                    )
+                    volumes.add(volume_name)
+                else:
+                    logger.debug(
+                        (
+                            "Volume '%s' determined to likely be a bind mount, "
+                            "not adding to the list of internal volumes"
+                        ),
+                        volume_name,
+                    )
+            logger.debug("Finished generating Docker Compose service configuration")
+
+    if volumes:
+        compose_obj["volumes"] = list(volumes)
+
+    click.echo(yaml.safe_dump(compose_obj, explicit_start=True, sort_keys=False))

--- a/buildarr/cli/compose.py
+++ b/buildarr/cli/compose.py
@@ -53,11 +53,11 @@ logger = getLogger(__name__)
     help=(
         "Generate a Docker Compose file from a Buildarr configuration.\n\n"
         "This reads instance configurations from a Buildarr configuration file, "
-        "generates a Docker Compose file that could be used to boostrap the instances, "
+        "generates a Docker Compose file that could be used to bootstrap the instances, "
         "and outputs the file to standard output.\n\n"
         "There are a few additional limitations on the instance configurations: "
         "instance hostnames must not be set to IP addresses, and all instances "
-        "must have unique hostnames, unless the `--ignore-hostnamea' option "
+        "must have unique hostnames, unless the `--ignore-hostnames' option "
         "is set.\n\n"
         "If CONFIG-PATH is not defined, use `buildarr.yml' from the current directory."
     ),

--- a/buildarr/cli/exceptions.py
+++ b/buildarr/cli/exceptions.py
@@ -65,6 +65,14 @@ class TestConfigError(CLIError):
     pass
 
 
+class ComposeInvalidHostnameError(ComposeError):
+    """
+    Exception raised when the hostname configuration for Docker Compose services is invalid.
+    """
+
+    pass
+
+
 class ComposeNoPluginsDefinedError(ComposeError):
     """
     Exception raised when no plugin is configured or loaded when

--- a/buildarr/cli/exceptions.py
+++ b/buildarr/cli/exceptions.py
@@ -30,6 +30,14 @@ class CLIError(BuildarrError):
     pass
 
 
+class ComposeError(CLIError):
+    """
+    Exception raised in the `buildarr compose` command.
+    """
+
+    pass
+
+
 class DaemonError(CLIError):
     """
     Exception raised in the `buildarr daemon` command.
@@ -52,6 +60,24 @@ class RunError(DaemonError):
 class TestConfigError(CLIError):
     """
     Exception raised in the `buildarr test-config` command.
+    """
+
+    pass
+
+
+class ComposeNoPluginsDefinedError(ComposeError):
+    """
+    Exception raised when no plugin is configured or loaded when
+    generating a Docker Compose environment.
+    """
+
+    pass
+
+
+class ComposeNotSupportedError(ComposeError):
+    """
+    Exception raised when an unsupported plugin is used when trying to
+    generate a Docker Compose file.
     """
 
     pass

--- a/buildarr/cli/main.py
+++ b/buildarr/cli/main.py
@@ -24,6 +24,7 @@ from __future__ import annotations
 from ..plugins import load as load_plugins
 from ..state import state
 from . import cli as main
+from .compose import compose
 from .daemon import daemon
 from .run import run
 from .test_config import test_config

--- a/buildarr/config/buildarr.py
+++ b/buildarr/config/buildarr.py
@@ -19,13 +19,15 @@ Buildarr settings configuration.
 
 from __future__ import annotations
 
+import os
+
 from datetime import time
 from pathlib import Path
 from typing import Set
 
 from pydantic import AnyHttpUrl, PositiveFloat
 
-from ..types import DayOfWeek, LocalPath
+from ..types import DayOfWeek, LocalPath, NonEmptyStr
 from .base import ConfigBase
 
 
@@ -150,4 +152,20 @@ class BuildarrConfig(ConfigBase):
     trash_metadata_dir_prefix: Path = Path("Guides-master")
     """
     Metadata directory name within the downloaded ZIP file.
+    """
+
+    docker_image_uri: NonEmptyStr = os.environ.get(  # type: ignore[assignment]
+        "BUILDARR_DOCKER_IMAGE_URI",
+        "callum027/buildarr",
+    )
+    """
+    Default image URI to use for the Buildarr service when generating Docker Compose files.
+
+    If undefined in the configuration file, use the value defined in the
+    `$BUILDARR_DOCKER_IMAGE_URI` environment variable. This allows third-party
+    Docker images to customise the version of Buildarr used in the command.
+
+    If no environment variable is found, use `callum027/buildarr` (the official Docker image).
+
+    *New in version 0.4.0.*
     """

--- a/buildarr/config/models.py
+++ b/buildarr/config/models.py
@@ -198,6 +198,22 @@ class ConfigPlugin(ConfigBase[Secrets]):
         """
         return self
 
+    def to_compose_service(self, compose_version: str, service_name: str) -> Dict[str, Any]:
+        """
+        Generate a Docker Compose service definition corresponding to this instance configuration.
+
+        Plugins should implement this function to allow Docker Compose files to be generated from
+        Buildarr configuration using the `buildarr compose` command.
+
+        Args:
+            compose_version (str): Version of the Docker Compose file.
+            service_name (str): The unique name for the generated Docker Compose service.
+
+        Returns:
+            Docker Compose service definition dictionary
+        """
+        raise NotImplementedError()
+
     @root_validator
     def _set_default_hostname(cls, values: Dict[str, Any]) -> Dict[str, Any]:
         """

--- a/buildarr/manager/__init__.py
+++ b/buildarr/manager/__init__.py
@@ -27,7 +27,7 @@ from ..state import state
 
 if TYPE_CHECKING:
     from pathlib import Path
-    from typing import Dict, Optional, Set
+    from typing import Any, Dict, Optional, Set
 
 
 logger = getLogger(__name__)
@@ -82,7 +82,7 @@ class ManagerPlugin(Generic[Config, Secrets]):
         Returns whether or not the given instance configuration uses TRaSH-Guides metadata.
 
         Args:
-            config (Config): Configuration object to check
+            instance_config (Config): Instance configuration object to check.
 
         Returns:
             `True` if TRaSH-Guides metadata is used, otherwise `False`
@@ -95,7 +95,7 @@ class ManagerPlugin(Generic[Config, Secrets]):
         with all templates rendered.
 
         Args:
-            config (Config): Configuration object to read.
+            instance_config (Config): Instance configuration object to render.
             trash_metadata_dir (Path): TRaSH-Guides metadata directory.
 
         Returns:
@@ -105,10 +105,10 @@ class ManagerPlugin(Generic[Config, Secrets]):
 
     def from_remote(self, instance_config: Config, secrets: Secrets) -> Config:
         """
-        Get the remote instance configuration for this section, and return the resulting object.
+        Get the active configuration for a remote instance, and return the resulting object.
 
         Args:
-            config (Config): Configuration object to read.
+            instance_config (Config): Configuration object of the instance to connect to.
             secrets (Secrets): Remote instance host and secrets information.
 
         Returns:
@@ -139,6 +139,28 @@ class ManagerPlugin(Generic[Config, Secrets]):
             tree=tree,
             secrets=secrets,
             remote=remote_instance_config,
+        )
+
+    def to_compose_service(
+        self,
+        instance_config: Config,
+        compose_version: str,
+        service_name: str,
+    ) -> Dict[str, Any]:
+        """
+        Generate a Docker Compose service definition corresponding to this instance configuration.
+
+        Args:
+            instance_config (Config): Instance configuration to generate a service for.
+            compose_version (str): Version of the Docker Compose file.
+            service_name (str): The unique name for the generated Docker Compose service.
+
+        Returns:
+            Docker Compose service definition dictionary
+        """
+        return instance_config.to_compose_service(
+            compose_version=compose_version,
+            service_name=service_name,
         )
 
 

--- a/buildarr/plugins/sonarr/config/__init__.py
+++ b/buildarr/plugins/sonarr/config/__init__.py
@@ -20,7 +20,7 @@ Sonarr plugin configuration.
 from __future__ import annotations
 
 from pathlib import Path
-from typing import TYPE_CHECKING, Dict, Optional
+from typing import TYPE_CHECKING, Any, Dict, Optional
 
 from typing_extensions import Self
 
@@ -255,12 +255,18 @@ class SonarrInstanceConfig(_SonarrInstanceConfig):
     This can only be done on Sonarr instances with authentication disabled.
     """
 
+    image: NonEmptyStr = "lscr.io/linuxserver/sonarr"  # type: ignore[assignment]
+    """
+    The default Docker image URI when generating a Docker Compose file.
+    """
+
     version: Optional[str] = None
     """
     The expected version of the Sonarr instance.
     If undefined or set to `None`, the version is auto-detected.
 
-    At the moment this attribute is unused, and there is likely no need to explicitly set it.
+    This value is also used when generating a Docker Compose file.
+    When undefined or set to `None`, the version tag will be set to `latest`.
     """
 
     settings: SonarrSettingsConfig = SonarrSettingsConfig()
@@ -330,6 +336,12 @@ class SonarrInstanceConfig(_SonarrInstanceConfig):
             version=api_get(secrets, "/api/v3/system/status")["version"],
             settings=SonarrSettingsConfig.from_remote(secrets),
         )
+
+    def to_compose_service(self, compose_version: str, service_name: str) -> Dict[str, Any]:
+        return {
+            "image": f"{self.image}:{self.version or 'latest'}",
+            "volumes": {service_name: "/config"},
+        }
 
 
 class SonarrConfig(SonarrInstanceConfig):

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -155,5 +155,6 @@ Buildarr operates on a principle of "don't touch what is not explicitly defined"
         - request_timeout
         - trash_metadata_download_url
         - trash_metadata_dir_prefix
+        - docker_image_uri
       show_root_heading: false
       show_source: false

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -90,7 +90,9 @@ services:
     container_name: buildarr
     restart: always
     volumes:
-      - ./buildarr:/config
+      - type: bind
+        source: ./buildarr
+        target: /config
     environment:
       TZ: Pacific/Auckland
       PUID: "1000"
@@ -132,6 +134,8 @@ sonarr:
       settings:
         ...
 ```
+
+*New in version 0.4.0*: Buildarr now supports [generating a Docker Compose file](usage.md#generating-a-docker-compose-file) from a Buildarr configuration file, using the `buildarr compose` command.
 
 ## Automatic deployment using Ansible
 


### PR DESCRIPTION
This PR adds a new `buildarr compose` CLI command for generating Docker Compose files from Buildarr configurations, and log the contents of the file to standard output.

The file itself is very basic and will probably require adjustment from the user to get it to work the way they want, but the Docker Compose file will have the following:

* Image tags matching the version defined in the Buildarr configuration file
* Restart policy set on all services
* Any required volumes created
* Service dependencies added based on instance-to-instance links present in the Buildarr configuration
* Buildarr itself added as a service in daemon mode, to deploy instance configurations and keep them up to date

To save the contents to the file, simply run:

```bash
buildarr compose /opt/buildarr/buildarr.yml > /opt/buildarr/docker-compose.yml
```

Example `buildarr.yml`:

```yaml
---
sonarr:
  instances:
    sonarr-hd: {}
    sonarr-4k:
      settings:
        media_management:
          root_folders:
            - /tmp/videos
        profiles:
          language_profiles:
            definitions:
              English:
                languages:
                  - "English"
        import_lists:
          definitions:
            "Sonarr (HD)":
              type: "sonarr"
              root_folder: "/tmp/videos"
              quality_profile: "Any"
              language_profile: "English"
              full_url: "http://sonarr-hd:8989"
              instance_name: "sonarr-hd"
```

Output `docker-compose.yml`:

```yaml
---
version: '3.7'
services:
  sonarr_sonarr-hd:
    image: lscr.io/linuxserver/sonarr:latest
    volumes:
      sonarr_sonarr-hd: /config
    hostname: sonarr-hd
    restart: always
  sonarr_sonarr-4k:
    image: lscr.io/linuxserver/sonarr:latest
    volumes:
      sonarr_sonarr-4k: /config
    hostname: sonarr-4k
    restart: always
    depends_on:
    - sonarr_sonarr-hd
  buildarr:
    image: callum027/buildarr:0.4.0
    command:
    - daemon
    - /config/buildarr.yml
    volumes:
    - type: bind
      source: /opt/buildarr
      target: /config
    restart: always
    depends_on:
    - sonarr_sonarr-hd
    - sonarr_sonarr-4k
volumes:
- sonarr_sonarr-4k
- sonarr_sonarr-hd
```