### PR TITLE
Reintroduce `buildarr.__version__` and use it internally

### DIFF
--- a/buildarr/__init__.py
+++ b/buildarr/__init__.py
@@ -1,0 +1,29 @@
+# Copyright (C) 2023 Callum Dickinson
+#
+# Buildarr is free software: you can redistribute it and/or modify it under the terms of the
+# GNU General Public License as published by the Free Software Foundation,
+# either version 3 of the License, or (at your option) any later version.
+#
+# Buildarr is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY;
+# without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+# See the GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License along with Buildarr.
+# If not, see <https://www.gnu.org/licenses/>.
+
+
+"""
+Buildarr root module.
+"""
+
+
+from __future__ import annotations
+
+from importlib_metadata import PackageNotFoundError, version as package_version
+
+__all__ = ["__version__"]
+
+try:
+    __version__: str = package_version("buildarr")
+except PackageNotFoundError:
+    __version__ = "0.1.0"

--- a/buildarr/cli/compose.py
+++ b/buildarr/cli/compose.py
@@ -28,8 +28,7 @@ from typing import TYPE_CHECKING, cast
 import click
 import yaml
 
-from importlib_metadata import version as package_version
-
+from .. import __version__
 from ..config import load_config, load_instance_configs, resolve_instance_dependencies
 from ..logging import get_log_level
 from ..manager import load_managers
@@ -133,11 +132,7 @@ def compose(
         use_plugins (Set[str]): Plugins to load. If empty, use all plugins.
     """
 
-    logger.debug(
-        "Buildarr version %s (log level: %s)",
-        package_version("buildarr"),
-        get_log_level(),
-    )
+    logger.debug("Buildarr version %s (log level: %s)", __version__, get_log_level())
     logger.debug(
         "Plugins loaded: %s",
         ", ".join(sorted(state.plugins.keys())) if state.plugins else "(no plugins found)",
@@ -266,7 +261,7 @@ def compose(
 
     logger.debug("Generating Docker Compose configuration for service 'buildarr'")
     compose_obj["services"]["buildarr"] = {
-        "image": f"{state.config.buildarr.docker_image_uri}:{package_version('buildarr')}",
+        "image": f"{state.config.buildarr.docker_image_uri}:{__version__}",
         "command": ["daemon", f"/config/{state.config_files[0].name}"],
         "volumes": [
             {"type": "bind", "source": str(state.config_files[0].parent), "target": "/config"},

--- a/buildarr/cli/daemon.py
+++ b/buildarr/cli/daemon.py
@@ -30,11 +30,11 @@ from typing import TYPE_CHECKING, cast
 
 import click
 
-from importlib_metadata import version as package_version
 from schedule import Job as SchedulerJob, Scheduler  # type: ignore[import]
 from watchdog.events import FileSystemEventHandler
 from watchdog.observers import Observer
 
+from .. import __version__
 from ..config import load_config
 from ..logging import get_log_level
 from ..state import state
@@ -458,11 +458,7 @@ def daemon(
         update_times (Tuple[time, ...]): Override `update_times` setting
     """
 
-    logger.info(
-        "Buildarr version %s (log level: %s)",
-        package_version("buildarr"),
-        get_log_level(),
-    )
+    logger.info("Buildarr version %s (log level: %s)", __version__, get_log_level())
 
     Daemon(
         config_path=config_path,

--- a/buildarr/cli/run.py
+++ b/buildarr/cli/run.py
@@ -26,8 +26,7 @@ from typing import Dict, Optional, Set
 
 import click
 
-from importlib_metadata import version as package_version
-
+from .. import __version__
 from ..config import load_config, load_instance_configs, resolve_instance_dependencies
 from ..logging import get_log_level
 from ..manager import load_managers
@@ -118,11 +117,7 @@ def run(
         plugins (Set[str]): Plugins to load. If empty, use all plugins.
     """
 
-    logger.info(
-        "Buildarr version %s (log level: %s)",
-        package_version("buildarr"),
-        get_log_level(),
-    )
+    logger.info("Buildarr version %s (log level: %s)", __version__, get_log_level())
 
     if dry_run:
         logger.info(

--- a/buildarr/cli/test_config.py
+++ b/buildarr/cli/test_config.py
@@ -26,8 +26,7 @@ from typing import TYPE_CHECKING
 
 import click
 
-from importlib_metadata import version as package_version
-
+from .. import __version__
 from ..config import load_config, load_instance_configs, resolve_instance_dependencies
 from ..logging import get_log_level
 from ..manager import load_managers
@@ -91,11 +90,7 @@ def test_config(config_path: Path, use_plugins: Set[str]) -> None:
         use_plugins (Set[str]): Plugins to load. If empty, use all plugins.
     """
 
-    logger.info(
-        "Buildarr version %s (log level: %s)",
-        package_version("buildarr"),
-        get_log_level(),
-    )
+    logger.info("Buildarr version %s (log level: %s)", __version__, get_log_level())
     logger.info(
         "Plugins loaded: %s",
         ", ".join(sorted(state.plugins.keys())) if state.plugins else "(no plugins found)",

--- a/buildarr/plugins/dummy/server.py
+++ b/buildarr/plugins/dummy/server.py
@@ -35,8 +35,9 @@ from __future__ import annotations
 from typing import TYPE_CHECKING, Mapping, cast
 
 from flask import Flask, Response, jsonify, request
-from importlib_metadata import version as package_version
 from werkzeug.exceptions import Unauthorized
+
+from buildarr import __version__
 
 if TYPE_CHECKING:
     from typing import Any, Dict, Tuple
@@ -111,7 +112,7 @@ def get_initialize_js() -> Tuple[str, int]:
     res = f"window.Dummy = {{\n  apiRoot: {repr(app.config['API_ROOT'])}"
     if "API_KEY" in app.config and app.config["API_KEY"]:
         res += f",\n  apiKey: {repr(app.config['API_KEY'])}"
-    res += f",\n  version: {repr(package_version('buildarr'))}\n}};"
+    res += f",\n  version: {repr(__version__)}\n}};"
 
     return (res, 200)
 
@@ -132,7 +133,7 @@ def get_status() -> Tuple[Response, int]:
 
     check_api_key()
 
-    return (jsonify({"version": package_version("buildarr")}), 200)
+    return (jsonify({"version": __version__}), 200)
 
 
 @app.get(f"{app.config['API_ROOT']}/settings")


### PR DESCRIPTION
Use `importlib_metadata.version` to create `buildarr.__version__` and use it wherever the version of Buildarr is required.