### PR TITLE
Add `version` attribute to plugin metadata object

### DIFF
--- a/buildarr/cli/compose.py
+++ b/buildarr/cli/compose.py
@@ -133,9 +133,10 @@ def compose(
     """
 
     logger.debug("Buildarr version %s (log level: %s)", __version__, get_log_level())
+    plugin_strs = [f"{pn} ({state.plugins[pn].version})" for pn in sorted(state.plugins.keys())]
     logger.debug(
-        "Plugins loaded: %s",
-        ", ".join(sorted(state.plugins.keys())) if state.plugins else "(no plugins found)",
+        "Loaded plugins: %s",
+        ", ".join(plugin_strs) if plugin_strs else "(no plugins found)",
     )
     logger.debug(
         "Creating Docker Compose file from configuration file: %s",

--- a/buildarr/cli/main.py
+++ b/buildarr/cli/main.py
@@ -37,7 +37,8 @@ load_plugins()
 
 # Load CLI modules for all installed plugins.
 for plugin_name, plugin in state.plugins.items():
-    main.add_command(plugin.cli, name=plugin_name)
+    if plugin.cli is not None:
+        main.add_command(plugin.cli, name=plugin_name)
 
 if __name__ == "__main__":
     main()

--- a/buildarr/cli/run.py
+++ b/buildarr/cli/run.py
@@ -156,9 +156,10 @@ def _run(secrets_file_path: Path, use_plugins: Optional[Set[str]] = None) -> Non
         logger.debug(indent(config_line, "  "))
 
     # Output the currently loaded plugins to the logs.
+    plugin_strs = [f"{pn} ({state.plugins[pn].version})" for pn in sorted(state.plugins.keys())]
     logger.info(
-        "Plugins loaded: %s",
-        ", ".join(sorted(state.plugins.keys())) if state.plugins else "(no plugins found)",
+        "Loaded plugins: %s",
+        ", ".join(plugin_strs) if plugin_strs else "(no plugins found)",
     )
 
     # Load the manager object for each plugin into global state.

--- a/buildarr/cli/test_config.py
+++ b/buildarr/cli/test_config.py
@@ -91,9 +91,10 @@ def test_config(config_path: Path, use_plugins: Set[str]) -> None:
     """
 
     logger.info("Buildarr version %s (log level: %s)", __version__, get_log_level())
+    plugin_strs = [f"{pn} ({state.plugins[pn].version})" for pn in sorted(state.plugins.keys())]
     logger.info(
-        "Plugins loaded: %s",
-        ", ".join(sorted(state.plugins.keys())) if state.plugins else "(no plugins found)",
+        "Loaded plugins: %s",
+        ", ".join(plugin_strs) if plugin_strs else "(no plugins found)",
     )
     logger.info("Testing configuration file: %s", str(config_path))
 

--- a/buildarr/plugins/dummy/plugin.py
+++ b/buildarr/plugins/dummy/plugin.py
@@ -19,6 +19,7 @@ Dummy plugin interface.
 
 from __future__ import annotations
 
+from buildarr import __version__
 from buildarr.plugins import Plugin
 
 from .cli import dummy
@@ -36,3 +37,4 @@ class DummyPlugin(Plugin):
     config = DummyConfig
     manager = DummyManager
     secrets = DummySecrets
+    version = __version__

--- a/buildarr/plugins/models.py
+++ b/buildarr/plugins/models.py
@@ -22,7 +22,7 @@ from __future__ import annotations
 from typing import TYPE_CHECKING
 
 if TYPE_CHECKING:
-    from typing import Type
+    from typing import Optional, Type
 
     from click import Group as ClickGroup
 
@@ -87,7 +87,46 @@ class Plugin:
     ```
     """
 
-    cli: ClickGroup
+    cli: Optional[ClickGroup] = None
+    """
+    CLI command group for the plugin.
+
+    This attribute is optional.
+
+    If you would like to add custom commands for your plugin to the Buildarr CLI,
+    create a `@click.group` function with the commands defined, and set this attribute
+    to the group function.
+    """
+
     config: Type[ConfigPlugin]
+    """
+    Configuration model for the plugin.
+
+    Buildarr uses this to parse configuration for the plugin defined in the Buildarr
+    configuration file. Most of the actual methods for interacting with the configuration
+    and remote instances will also be defined in the model structure.
+    """
+
     manager: Type[ManagerPlugin]
+    """
+    Manager class for the plugin.
+
+    Buildarr instantiates an object of this class without any arguments, and
+    runs operations on configurations and secrets metadata through the methods
+    defined in this class.
+    """
+
     secrets: Type[SecretsPlugin]
+    """
+    Secrets metadata model for the plugin.
+
+    Buildarr uses this to parse and create secrets metadata objects that the plugin can use.
+    """
+
+    version: str
+    """
+    The version of the plugin package.
+
+    Gets output to the Buildarr logs so the user knows what version of the plugin
+    is installed.
+    """

--- a/buildarr/plugins/sonarr/plugin.py
+++ b/buildarr/plugins/sonarr/plugin.py
@@ -19,6 +19,7 @@ Sonarr plugin interface.
 
 from __future__ import annotations
 
+from buildarr import __version__
 from buildarr.plugins import Plugin
 
 from .cli import sonarr
@@ -36,3 +37,4 @@ class SonarrPlugin(Plugin):
     config = SonarrConfig
     manager = SonarrManager
     secrets = SonarrSecrets
+    version = __version__


### PR DESCRIPTION
* Add required `version` attribute to the `Plugin` class, and define it on vendored plugins
* Make the `cli` attribute of the `Plugin` class optional
* Add docstrings for all `Plugin` class attributes