### PR TITLE
Fix mistakes in error messages

### DIFF
--- a/buildarr/cli/compose.py
+++ b/buildarr/cli/compose.py
@@ -203,7 +203,7 @@ def compose(
             if hostname == "localhost":
                 raise ComposeInvalidHostnameError(
                     f"Invalid hostname '{hostname}' for {plugin_name} instance '{instance_name}': "
-                    "Hostname must not be localhost for Docker Compose servies",
+                    "Hostname must not be localhost for Docker Compose services",
                 )
             if hostname in hostnames:
                 raise ComposeInvalidHostnameError(

--- a/buildarr/cli/daemon.py
+++ b/buildarr/cli/daemon.py
@@ -382,7 +382,7 @@ def parse_time(
         try:
             times.append(datetime.strptime(time_str, "%H:%M").time())
         except ValueError:
-            raise click.BadParameter(f"Invalid 24 hour time '{time_str}") from None
+            raise click.BadParameter(f"Invalid 24 hour time '{time_str}'") from None
     return tuple(times)
 
 

--- a/buildarr/config/base.py
+++ b/buildarr/config/base.py
@@ -212,7 +212,7 @@ class ConfigBase(BaseModel, Generic[Secrets]):
                                 else:
                                     raise ValueError(
                                         "'value' attribute not included "
-                                        f"for remote field '{remote_attr_name}'"
+                                        f"for remote field '{remote_attr_name}' "
                                         "and 'field_default' not defined in local attribute",
                                     ) from None
                             break


### PR DESCRIPTION
Fixes some minor spelling and formatting mistakes in some error messages.

The errors worked, but were just not as they were intended to be.