### PR TITLE
Update Buildarr docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -186,7 +186,6 @@ For more information on how to interfact with Buildarr, check the [usage documen
     * Radarr
     * Prowlarr (now available as [`buildarr-prowlarr`](https://buildarr.github.io/plugins/prowlarr))
     * Bazarr
-    * FlareSolverr
     * Unmanic
     * Tdarr (maybe)
     * Unpackerr

--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ Buildarr attempts to fulfill some of the needs of users of the following project
 
 Buildarr is available on Docker Hub as a Docker image.
 
-A plugin for Sonarr is bundled into the official Docker container for Buildarr, so you can manage Sonarr instances right away.
+Plugins for Sonarr and Prowlarr are bundled into the official Docker container for Buildarr, so you can manage instances of those types right away.
 
 ```bash
 $ docker pull callum027/buildarr:latest
@@ -56,6 +56,7 @@ Buildarr supports external plugins to allow additional applications to be suppor
 At the time of this release the following plugins are available:
 
 * [`buildarr-sonarr`](https://buildarr.github.io/plugins/sonarr) - [Sonarr](https://sonarr.tv) PVR for TV shows
+* [`buildarr-prowlarr`](https://buildarr.github.io/plugins/prowlarr) - [Prowlarr](https://prowlarr.com) indexer manager for Arr applications
 
 For more information on installing plugins, check the [plugin documentation](http://buildarr.github.io/plugins).
 
@@ -183,7 +184,7 @@ For more information on how to interfact with Buildarr, check the [usage documen
 * Create plugins for the following applications:
     * Sonarr V4
     * Radarr
-    * Prowlarr
+    * Prowlarr (now available as [`buildarr-prowlarr`](https://buildarr.github.io/plugins/prowlarr))
     * Bazarr
     * FlareSolverr
     * Unmanic

--- a/docs/index.md
+++ b/docs/index.md
@@ -190,7 +190,6 @@ For more information on how to interfact with Buildarr, check the [usage documen
     * Radarr
     * Prowlarr (now available as [`buildarr-prowlarr`](https://buildarr.github.io/plugins/prowlarr))
     * Bazarr
-    * FlareSolverr
     * Unmanic
     * Tdarr (maybe)
     * Unpackerr

--- a/docs/index.md
+++ b/docs/index.md
@@ -27,7 +27,7 @@ Buildarr attempts to fulfill some of the needs of users of the following project
 
 Buildarr is available on Docker Hub as a Docker image.
 
-A plugin for Sonarr is bundled into the official Docker container for Buildarr, so you can manage Sonarr instances right away.
+Plugins for Sonarr and Prowlarr are bundled into the official Docker container for Buildarr, so you can manage instances of those types right away.
 
 ```bash
 $ docker pull callum027/buildarr:latest
@@ -54,6 +54,7 @@ Buildarr supports external plugins to allow additional applications to be suppor
 At the time of this release the following plugins are available:
 
 * [`buildarr-sonarr`](https://buildarr.github.io/plugins/sonarr) - [Sonarr](https://sonarr.tv) PVR for TV shows
+* [`buildarr-prowlarr`](https://buildarr.github.io/plugins/prowlarr) - [Prowlarr](https://prowlarr.com) indexer manager for Arr applications
 
 For more information on installing plugins, check the [plugin documentation](plugins/index.md).
 
@@ -187,7 +188,7 @@ For more information on how to interfact with Buildarr, check the [usage documen
 * Create plugins for the following applications:
     * Sonarr V4
     * Radarr
-    * Prowlarr
+    * Prowlarr (now available as [`buildarr-prowlarr`](https://buildarr.github.io/plugins/prowlarr))
     * Bazarr
     * FlareSolverr
     * Unmanic

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -42,6 +42,12 @@ Buildarr is available on Docker Hub as a Docker image.
 $ docker pull callum027/buildarr:latest
 ```
 
+!!! note
+
+    Because the Docker container is a bundle of packages consisting of Buildarr and implementing plugins, it has a separate version number from Buildarr itself.
+
+    For more information, check out the [Docker Hub page](https://hub.docker.com/r/callum027/buildarr) for the Buildarr Docker container.
+
 Once you have a configuration file, create a folder to store the configuration and auto-generated secrets files to mount into the Docker container.
 
 As API keys and login credentials are to be stored here, they should have strict permissions set, with ownership exclusively
@@ -66,7 +72,7 @@ For configuration testing purposes, you can call `buildarr run` using the Docker
 $ docker run --rm -v /path/to/config:/config -e PUID=<PUID> -e PGID=<PGID> callum027/buildarr:latest run
 ```
 
-The Docker container for Buildarr is bundled with the Sonarr plugin, so Sonarr instances can be managed out of the box.
+The Docker container for Buildarr is bundled with the [Sonarr plugin](https://buildarr.github.io/plugins/sonarr) and the [Prowlarr plugin](https://buildarr.github.io/plugins/prowlarr), so instances of those types can be managed out of the box.
 
 If you would like to install external plugins into the Docker container, see [Installing plugins into the Docker container](plugins/index.md#installing-plugins-into-the-docker-container).
 

--- a/docs/plugins/index.md
+++ b/docs/plugins/index.md
@@ -22,7 +22,8 @@ Buildarr plugins are installed as Python packages, just like Buildarr itself.
 
 At the time of this release the following plugins are available:
 
-* [buildarr-sonarr](https://buildarr.github.io/plugins/sonarr) - [Sonarr](https://sonarr.tv) PVR for TV shows
+* [`buildarr-sonarr`](https://buildarr.github.io/plugins/sonarr) - [Sonarr](https://sonarr.tv) PVR for TV shows
+* [`buildarr-prowlarr`](https://buildarr.github.io/plugins/prowlarr) - [Prowlarr](https://prowlarr.com) indexer manager for Arr applications
 
 ## Installing plugins for a standalone application
 
@@ -45,5 +46,11 @@ If you would like to install an external plugin that is not bundled, the Buildar
 ```bash
 $ docker run -d --name buildarr --restart=always -v /path/to/config:/config -e PUID=<PUID> -e PGID=<PGID> -e BUILDARR_INSTALL_PLUGINS="buildarr-sonarr" callum027/buildarr:latest
 ```
+
+If you would like to upgrade Buildarr itself or the bundled plugins within the container, set the following environment variables to the version you would like to install:
+
+* `$BUILDARR_VERSION`
+* `$BUILDARR_SONARR_VERSION`
+* `$BUILDARR_PROWLARR_VERSION`
 
 For more information on installing Buildarr as a Docker container, see the [Docker installation instructions](../installation.md#docker).

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -17,14 +17,15 @@ markdown_extensions:
   - pymdownx.superfences
 
 nav:
-  - Home: "index.md"
   - Release Notes: "release-notes.md"
   - Installation: "installation.md"
   - Configuration: "configuration.md"
   - Plugins:
     - Introduction: "plugins/index.md"
     - Buildarr Sonarr Plugin: "https://buildarr.github.io/plugins/sonarr"
+    - Buildarr Prowlarr Plugin: "https://buildarr.github.io/plugins/prowlarr"
   - Usage: "usage.md"
+  - GitHub: "https://github.com/buildarr/buildarr"
   # TODO: Development documentation.
   # - Development:
   #   - Introduction: "development/index.md"

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -1,4 +1,4 @@
-site_name: Buildarr
+site_name: Buildarr Core
 
 plugins:
   - search


### PR DESCRIPTION
* Add Prowlarr as a newly released plugin, also now bundled with the Docker image
* Add additional documentation for the nature of the Docker container and how to upgrade the bundled packages
* Remove FlareSolverr from the to-do list as creating a plugin for it in Buildarr is unnecessary