### PR TITLE
Deprecate `BaseIntEnum`

### DIFF
--- a/buildarr/secrets/base.py
+++ b/buildarr/secrets/base.py
@@ -21,9 +21,10 @@ from __future__ import annotations
 
 from typing import TYPE_CHECKING, Generic
 
-from pydantic import BaseModel, SecretStr
+from pydantic import BaseModel
 
 from ..plugins import Config
+from ..types import ModelConfigBase
 
 if TYPE_CHECKING:
     from pathlib import Path
@@ -60,7 +61,37 @@ class SecretsBase(BaseModel, Generic[Config]):
         """
         path.write_text(self.json())
 
-    class Config:
-        json_encoders = {SecretStr: lambda v: v.get_secret_value()}
-        validate_all = True
+    class Config(ModelConfigBase):
+        """
+        Buildarr secrets model class settings.
+
+        Sets some required parameters for serialisation,
+        parsing and validation to work correctly.
+
+        To set additional parameters in your implementing class, subclass this class:
+
+        ```python
+        from __future__ import annotations
+
+        from typing import TYPE_CHECKING
+        from buildarr.secrets import SecretsBase
+
+        if TYPE_CHECKING:
+            from .config import ExampleConfig
+            class _ExampleSecrets(SecretsBase[ExampleSecrets]):
+                ...
+        else:
+            class _ExampleSecrets(SecretsBase):
+                ...
+
+        class ExampleSecrets(_ExampleSecrets):
+            ...
+
+            class Config(_ExampleSecrets.Config):
+                ...  # Add model configuration attributes here.
+        ```
+        """
+
+        # Validate any values that have been modified in-place, to ensure the model
+        # still fits the constraints.
         validate_assignment = True


### PR DESCRIPTION
Having thoroughly investigated the cause of it not being serialised consistently, I determined that it was infeasible to get it working as it should, given the nature of `BaseIntEnum` as a subclass of `int`.

At this stage of development we can still remove functionality that is not working as intended.

Therefore deprecate it, in preparation for removal in version 0.5.0 (the next backward-incompatible release).

Also make the following changes:

* Add `BaseIntEnum` it to where it should have been added when implemented (the Buildarr API decoding, formatting, and encoding functions), so while it still won't produce the correct result when dumping configuration files, it will at least work properly for updating instances in the mean time, while it's available.
* Refactor all models (`ConfigBase`, `SecretsBase`) to use a common model configuration base class, and set sane defaults for all of them.