### PR TITLE
Add Buildarr run stage for initialising new instances

### DIFF
--- a/buildarr/cli/run.py
+++ b/buildarr/cli/run.py
@@ -191,7 +191,7 @@ def _run(secrets_file_path: Path, use_plugins: Optional[Set[str]] = None) -> Non
     logger.info("Finished resolving instance dependencies")
 
     # Initialise any instances that have not been initialised yet.
-    # For applicable instance, this needs to be done before the main API can be queried,
+    # For applicable instances, this needs to be done before the main API can be queried,
     # or secrets can even be checked.
     for plugin_name, instance_name in state._execution_order:
         manager = state.managers[plugin_name]

--- a/buildarr/cli/run.py
+++ b/buildarr/cli/run.py
@@ -190,6 +190,34 @@ def _run(secrets_file_path: Path, use_plugins: Optional[Set[str]] = None) -> Non
         logger.debug("  %i. %s.instances[%s]", i, plugin_name, repr(instance_name))
     logger.info("Finished resolving instance dependencies")
 
+    # Initialise any instances that have not been initialised yet.
+    # For applicable instance, this needs to be done before the main API can be queried,
+    # or secrets can even be checked.
+    for plugin_name, instance_name in state._execution_order:
+        manager = state.managers[plugin_name]
+        instance_config = state.instance_configs[plugin_name][instance_name]
+        with state._with_context(plugin_name=plugin_name, instance_name=instance_name):
+            logger.debug("Checking if the instance is initialised")
+            try:
+                is_initialized = manager.is_initialized(instance_config)
+            except NotImplementedError:
+                logger.debug("Initialisation is not required for this instance type")
+                continue
+            if is_initialized:
+                logger.debug("Instance is initialised and ready for configuration updates")
+            else:
+                logger.info("Instance has not been initialised")
+                logger.info("Initialising instance")
+                manager.initialize(
+                    (
+                        plugin_name
+                        if instance_name == "default"
+                        else f"{plugin_name}.instances[{repr(instance_config)}]"
+                    ),
+                    instance_config,
+                )
+                logger.info("Finished initialising instance")
+
     # Load the secrets file if it exists, and initialise the secrets metadata.
     # If `use_plugins` is undefined, load using all plugins available
     # to preserve cached secrets metadata that isn't used.

--- a/buildarr/config/models.py
+++ b/buildarr/config/models.py
@@ -198,6 +198,40 @@ class ConfigPlugin(ConfigBase[Secrets]):
         """
         return self
 
+    def is_initialized(self) -> bool:
+        """
+        Return whether or not this instance needs to be initialised.
+
+        This function runs after the instance configuration has been rendered,
+        but before secrets are fetched.
+
+        Configuration plugins should implement this function if initialisation is required
+        for the application's API to become available.
+
+        Raises:
+            NotImplementedError: When initialisation is not required for application type.
+
+        Returns:
+            `True` if the instance is initialised, otherwise `False`
+        """
+        raise NotImplementedError()
+
+    def initialize(self, tree: str) -> None:
+        """
+        Initialise the instance, and make the main application API available for Buildarr
+        to query against.
+
+        This function runs after the instance configuration has been rendered,
+        but before secrets are fetched.
+
+        Configuration plugins should implement this function if initialisation is required
+        for the application's API to become available.
+
+        Args:
+            tree (str): Configuration tree this instance falls under (for logging purposes).
+        """
+        raise NotImplementedError()
+
     def to_compose_service(self, compose_version: str, service_name: str) -> Dict[str, Any]:
         """
         Generate a Docker Compose service definition corresponding to this instance configuration.

--- a/buildarr/config/models.py
+++ b/buildarr/config/models.py
@@ -209,7 +209,7 @@ class ConfigPlugin(ConfigBase[Secrets]):
         for the application's API to become available.
 
         Raises:
-            NotImplementedError: When initialisation is not required for application type.
+            NotImplementedError: When initialisation is not required for the application type.
 
         Returns:
             `True` if the instance is initialised, otherwise `False`

--- a/buildarr/manager/__init__.py
+++ b/buildarr/manager/__init__.py
@@ -114,7 +114,7 @@ class ManagerPlugin(Generic[Config, Secrets]):
             instance_config (Config): Instance configuration object to initialise.
 
         Raises:
-            NotImplementedError: When initialisation is not required for application type.
+            NotImplementedError: When initialisation is not required for the application type.
 
         Returns:
             `True` if the instance is initialised, otherwise `False`

--- a/buildarr/manager/__init__.py
+++ b/buildarr/manager/__init__.py
@@ -103,6 +103,38 @@ class ManagerPlugin(Generic[Config, Secrets]):
         """
         return instance_config.render_trash_metadata(trash_metadata_dir)
 
+    def is_initialized(self, instance_config: Config) -> bool:
+        """
+        Return whether or not this instance needs to be initialised.
+
+        This function runs after the instance configuration has been rendered,
+        but before secrets are fetched.
+
+        Args:
+            instance_config (Config): Instance configuration object to initialise.
+
+        Raises:
+            NotImplementedError: When initialisation is not required for application type.
+
+        Returns:
+            `True` if the instance is initialised, otherwise `False`
+        """
+        return instance_config.is_initialized()
+
+    def initialize(self, tree: str, instance_config: Config) -> None:
+        """
+        Initialise the instance, and make the main application API available for Buildarr
+        to query against.
+
+        This function runs after the instance configuration has been rendered,
+        but before secrets are fetched.
+
+        Args:
+            tree (str): Configuration tree this instance falls under (for logging purposes).
+            instance_config (Config): Instance configuration object to initialise.
+        """
+        instance_config.initialize(tree)
+
     def from_remote(self, instance_config: Config, secrets: Secrets) -> Config:
         """
         Get the active configuration for a remote instance, and return the resulting object.


### PR DESCRIPTION
* Add the `is_initialized` and `initialize` manager functions, which hook into corresponding functions of the same name on the configuration base class
* Run the above functions after rendering the instance configuration but **before** querying the instance API for anything (secrets, getting remote config, etc)
* Detect when initialisation is not required/not implemented for an instance and skip them