### PR TITLE
Add generic configuration rendering stage

### DIFF
--- a/buildarr/config/__init__.py
+++ b/buildarr/config/__init__.py
@@ -23,6 +23,7 @@ from .base import ConfigBase
 from .exceptions import ConfigError, ConfigTrashIDNotFoundError
 from .load import load_config, load_instance_configs
 from .models import ConfigPlugin, ConfigPluginType, ConfigType
+from .render_instance_configs import render_instance_configs
 from .resolve_instance_dependencies import resolve_instance_dependencies
 from .types import RemoteMapEntry
 
@@ -37,4 +38,5 @@ __all__ = [
     "load_config",
     "load_instance_configs",
     "resolve_instance_dependencies",
+    "render_instance_configs",
 ]

--- a/buildarr/config/models.py
+++ b/buildarr/config/models.py
@@ -198,6 +198,18 @@ class ConfigPlugin(ConfigBase[Secrets]):
         """
         return self
 
+    def render(self) -> Self:
+        """
+        Render any dynamically populated attributes in this instance configuration.
+
+        Configuration plugins should implement this function if there are any attributes
+        that get dynamically populated, e.g. TRaSH-Guides metadata.
+
+        Returns:
+            Rendered configuration object
+        """
+        return self
+
     def is_initialized(self) -> bool:
         """
         Return whether or not this instance needs to be initialised.

--- a/buildarr/config/render_instance_configs.py
+++ b/buildarr/config/render_instance_configs.py
@@ -1,0 +1,56 @@
+# Copyright (C) 2023 Callum Dickinson
+#
+# Buildarr is free software: you can redistribute it and/or modify it under the terms of the
+# GNU General Public License as published by the Free Software Foundation,
+# either version 3 of the License, or (at your option) any later version.
+#
+# Buildarr is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY;
+# without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+# See the GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License along with Buildarr.
+# If not, see <https://www.gnu.org/licenses/>.
+
+
+"""
+Buildarr configuration rendering function.
+"""
+
+
+from __future__ import annotations
+
+from collections import defaultdict
+from logging import getLogger
+from typing import TYPE_CHECKING
+
+from ..state import state
+
+if TYPE_CHECKING:
+    from typing import DefaultDict, Dict
+
+    from .models import ConfigPlugin
+
+logger = getLogger(__name__)
+
+
+def render_instance_configs() -> None:
+    """
+    Render dynamically populated attributes on instance configurations,
+    and update the global state.
+
+    If an instance configuration returned `True` for `uses_trash_metadata`,
+    the filepath to the downloaded metadata directory will be available as
+    `state.trash_metadata_dir` in the global state.
+    """
+
+    instance_configs: DefaultDict[str, Dict[str, ConfigPlugin]] = defaultdict(dict)
+
+    for plugin_name, instance_name in state._execution_order:
+        manager = state.managers[plugin_name]
+        instance_config = state.instance_configs[plugin_name][instance_name]
+        with state._with_context(plugin_name=plugin_name, instance_name=instance_name):
+            logger.debug("Rendering dynamic configuration attributes")
+            instance_configs[plugin_name][instance_name] = manager.render(instance_config)
+            logger.debug("Finished dynamic configuration attributes")
+
+    state.instance_configs = instance_configs

--- a/buildarr/manager/__init__.py
+++ b/buildarr/manager/__init__.py
@@ -103,6 +103,22 @@ class ManagerPlugin(Generic[Config, Secrets]):
         """
         return instance_config.render_trash_metadata(trash_metadata_dir)
 
+    def render(self, instance_config: Config) -> Config:
+        """
+        Render dynamically populated attributes on the given instance configuration.
+
+        If the instance configuration returned `True` for `uses_trash_metadata`,
+        the filepath to the downloaded metadata directory will be available as
+        `state.trash_metadata_dir` in the global state.
+
+        Args:
+            instance_config (Config): Instance configuration object to render.
+
+        Returns:
+            Rendered configuration object
+        """
+        return instance_config.render()
+
     def is_initialized(self, instance_config: Config) -> bool:
         """
         Return whether or not this instance needs to be initialised.

--- a/buildarr/state.py
+++ b/buildarr/state.py
@@ -101,6 +101,14 @@ class State:
     A data structure containing the names of all the currently active plugins.
     """
 
+    trash_metadata_dir: Path
+    """
+    TRaSH-Guides metadata directory.
+
+    Only available if required by at least one instance configuration,
+    during the render stage of a Buildarr run.
+    """
+
     secrets: SecretsType
     """
     Currently loaded instance secrets.
@@ -165,6 +173,7 @@ class State:
         self.managers = None  # type: ignore[assignment]
         self.instance_configs = None  # type: ignore[assignment]
         self.active_plugins = None  # type: ignore[assignment]
+        self.trash_metadata_dir = None  # type: ignore[assignment]
         self.secrets = None  # type: ignore[assignment]
         self._current_plugin = None  # type: ignore[assignment]
         self._current_instance = None  # type: ignore[assignment]


### PR DESCRIPTION
* Add the `render` manager and configuration function, which is planned to replace `render_trash_metadata`
* Add the TRaSH-Guides metadata directory to global state as `state.trash_metadata_dir`
* Move the rendering stage, TRaSH-specific or otherwise, to before instance initialisation and secrets fetching