### PR TITLE
Add resource deletion stage after configuration updates

### DIFF
--- a/buildarr/config/base.py
+++ b/buildarr/config/base.py
@@ -634,6 +634,41 @@ class ConfigBase(BaseModel, Generic[Secrets]):
         # Return the completed remote attribute dictionary structure.
         return (changed, remote_attrs)
 
+    def delete_remote(
+        self,
+        tree: str,
+        secrets: Secrets,
+        remote: Self,
+    ) -> bool:
+        """
+        Compare the local configuration to a remote instance, and delete any resources
+        that are unmanaged or unused on the remote, and allowed to be deleted.
+
+        This function should be overloaded by implementing classes with resources that
+        may need to be deleted from a remote instance if it is unmanaged by Buildarr
+        or simply unused.
+
+        The base function simply implements traversing the configuration tree
+        to call child section functions.
+
+        Args:
+            tree (str): Configuration tree represented as a string. Mainly used in logging.
+            secrets (Secrets): Remote instance host and secrets information.
+            remote (Self): Remote instance configuration for the current section.
+
+        Returns:
+            `True` if the remote configuration changed, otherwise `False`
+        """
+        changed = False
+        for field_name, field in self:
+            if isinstance(field, ConfigBase) and field.delete_remote(
+                f"{tree}.{field_name}",
+                secrets,
+                getattr(remote, field_name),
+            ):
+                changed = True
+        return changed
+
     @classmethod
     def _format_attr(cls, value: Any) -> Any:
         """

--- a/buildarr/manager/__init__.py
+++ b/buildarr/manager/__init__.py
@@ -189,6 +189,32 @@ class ManagerPlugin(Generic[Config, Secrets]):
             remote=remote_instance_config,
         )
 
+    def delete_remote(
+        self,
+        tree: str,
+        local_instance_config: Config,
+        secrets: Secrets,
+        remote_instance_config: Config,
+    ) -> bool:
+        """
+        Compare the local configuration to a remote instance, and delete any resources
+        that are unmanaged or unused on the remote, and allowed to be deleted.
+
+        Args:
+            tree (str): Configuration tree represented as a string. Mainly used in logging.
+            local_instance_config (Config): Local instance configuration to compare to the remote.
+            secrets (Secrets): Remote instance host and secrets information.
+            remote_instance_config (Config): Currently active remote instance configuration.
+
+        Returns:
+            `True` if the remote configuration changed, otherwise `False`
+        """
+        return local_instance_config.delete_remote(
+            tree=tree,
+            secrets=secrets,
+            remote=remote_instance_config,
+        )
+
     def to_compose_service(
         self,
         instance_config: Config,


### PR DESCRIPTION
Add the `delete_remote` manager and configuration model function, which gets called after `update_remote` has run on all configured instances in every plugin, as an additional pass.

This is intended to be used to delete unmanaged or unused resources marked as allowed to be deleted in the instance configuration (for example, unmanaged quality profiles in Sonarr with `delete_unmanaged` set to `true`).