### PR TITLE
Remove deprecated features for Buildarr v0.5.0

### DIFF
--- a/buildarr/cli/daemon.py
+++ b/buildarr/cli/daemon.py
@@ -129,7 +129,7 @@ class Daemon:
         self.update_daytimes = [
             (update_day, update_time)
             for update_day, update_time in itertools.product(
-                sorted(self.update_days),
+                sorted(self.update_days, key=lambda v: v.value),
                 sorted(self.update_times),
             )
         ]

--- a/buildarr/cli/daemon.py
+++ b/buildarr/cli/daemon.py
@@ -129,7 +129,7 @@ class Daemon:
         self.update_daytimes = [
             (update_day, update_time)
             for update_day, update_time in itertools.product(
-                sorted(self.update_days, key=lambda v: v.value),
+                sorted(self.update_days),
                 sorted(self.update_times),
             )
         ]

--- a/buildarr/cli/run.py
+++ b/buildarr/cli/run.py
@@ -37,7 +37,7 @@ from ..logging import get_log_level
 from ..manager import load_managers
 from ..secrets import load_secrets
 from ..state import state
-from ..trash import fetch_trash_metadata, render_trash_metadata, trash_metadata_used
+from ..trash import fetch_trash_metadata, trash_metadata_used
 from ..util import get_resolved_path
 from . import cli
 from .exceptions import RunInstanceConnectionTestFailedError, RunNoPluginsDefinedError
@@ -205,12 +205,8 @@ def _run(secrets_file_path: Path, use_plugins: Optional[Set[str]] = None) -> Non
     # only if at least one instance configuration requires it.
     if trash_metadata_used():
         logger.info("Fetching TRaSH metadata")
-        with fetch_trash_metadata() as trash_metadata_dir:
-            # TODO: Remove `render_trash_metadata` in Buildarr v0.5.0.
+        with fetch_trash_metadata():
             logger.info("Finished fetching TRaSH metadata")
-            logger.info("Rendering TRaSH metadata")
-            render_trash_metadata(trash_metadata_dir)
-            logger.info("Finished rendering TRaSH metadata")
             logger.info("Rendering instance configuration dynamic attributes")
             render_instance_configs()
             logger.info("Finished rendering instance configuration dynamic attributes")

--- a/buildarr/cli/test_config.py
+++ b/buildarr/cli/test_config.py
@@ -36,7 +36,7 @@ from ..config import (
 from ..logging import get_log_level
 from ..manager import load_managers
 from ..state import state
-from ..trash import fetch_trash_metadata, render_trash_metadata
+from ..trash import fetch_trash_metadata
 from ..util import get_resolved_path
 from . import cli
 from .exceptions import TestConfigNoPluginsDefinedError
@@ -181,20 +181,10 @@ def test_config(config_path: Path, use_plugins: Set[str]) -> None:
         fetching_metadata = True
         try:
             logger.debug("Fetching TRaSH metadata")
-            with fetch_trash_metadata() as trash_metadata_dir:
+            with fetch_trash_metadata():
                 logger.debug("Finished fetching TRaSH metadata")
                 logger.info("Fetching TRaSH-Guides metadata: PASSED")
                 fetching_metadata = False
-                # TODO: Remove `render_trash_metadata` in Buildarr v0.5.0.
-                try:
-                    logger.debug("Rendering TRaSH metadata")
-                    render_trash_metadata(trash_metadata_dir)
-                    logger.debug("Finished rendering TRaSH metadata")
-                except Exception:
-                    logger.error("Rendering TRaSH-Guides metadata: FAILED")
-                    raise
-                else:
-                    logger.info("Rendering TRaSH-Guides metadata: PASSED")
                 try:
                     logger.debug("Rendering instance configuration dynamic attributes")
                     render_instance_configs()
@@ -210,7 +200,6 @@ def test_config(config_path: Path, use_plugins: Set[str]) -> None:
             raise
     else:
         logger.info("Fetching TRaSH-Guides metadata: SKIPPED (not required)")
-        logger.info("Rendering TRaSH-Guides metadata: SKIPPED (not required)")
         try:
             logger.debug("Rendering instance configuration dynamic attributes")
             render_instance_configs()

--- a/buildarr/config/base.py
+++ b/buildarr/config/base.py
@@ -48,7 +48,7 @@ from pydantic.validators import _VALIDATORS
 from typing_extensions import Self
 
 from ..plugins import Secrets
-from ..types import BaseEnum, BaseIntEnum, ModelConfigBase
+from ..types import BaseEnum, ModelConfigBase
 from .types import RemoteMapEntry
 
 logger = getLogger(__name__)
@@ -681,7 +681,7 @@ class ConfigBase(BaseModel, Generic[Secrets]):
         Returns:
             The value to pass to the logging function
         """
-        if isinstance(value, (BaseEnum, BaseIntEnum)):
+        if isinstance(value, BaseEnum):
             return value.to_name_str()
         elif isinstance(value, AnyUrl):
             return str(value)
@@ -734,7 +734,7 @@ class ConfigBase(BaseModel, Generic[Secrets]):
                     [t for t in attr_union_types if t is not type(None)][0],
                     value,
                 )
-        elif issubclass(type_tree[-1], (BaseEnum, BaseIntEnum)):
+        elif issubclass(type_tree[-1], BaseEnum):
             return type_tree[-1](value)
         return value
 
@@ -749,7 +749,7 @@ class ConfigBase(BaseModel, Generic[Secrets]):
         Returns:
             Remote attribute value
         """
-        if isinstance(value, (BaseEnum, BaseIntEnum)):
+        if isinstance(value, BaseEnum):
             return value.value
         elif isinstance(value, AnyUrl):
             return str(value)

--- a/buildarr/config/models.py
+++ b/buildarr/config/models.py
@@ -19,7 +19,6 @@ Buildarr plugin configuration object models.
 
 from __future__ import annotations
 
-from pathlib import Path
 from typing import Any, Dict, Type, cast
 
 from pydantic import root_validator
@@ -183,20 +182,6 @@ class ConfigPlugin(ConfigBase[Secrets]):
                 ),
             ),
         )
-
-    def render_trash_metadata(self, trash_metadata_dir: Path) -> Self:
-        """
-        Read TRaSH-Guides metadata, and return a configuration object with all templates rendered.
-
-        Configuration plugins should implement this function if TRaSH-Guides metadata is used.
-
-        Args:
-            trash_metadata_dir (Path): TRaSH-Guides metadata directory.
-
-        Returns:
-            Rendered configuration object
-        """
-        return self
 
     def render(self) -> Self:
         """

--- a/buildarr/manager/__init__.py
+++ b/buildarr/manager/__init__.py
@@ -26,7 +26,6 @@ from ..plugins import Config, Secrets
 from ..state import state
 
 if TYPE_CHECKING:
-    from pathlib import Path
     from typing import Any, Dict, Optional, Set
 
 
@@ -88,20 +87,6 @@ class ManagerPlugin(Generic[Config, Secrets]):
             `True` if TRaSH-Guides metadata is used, otherwise `False`
         """
         return instance_config.uses_trash_metadata
-
-    def render_trash_metadata(self, instance_config: Config, trash_metadata_dir: Path) -> Config:
-        """
-        Read TRaSH-Guides metadata, and return an instance configuration object
-        with all templates rendered.
-
-        Args:
-            instance_config (Config): Instance configuration object to render.
-            trash_metadata_dir (Path): TRaSH-Guides metadata directory.
-
-        Returns:
-            Rendered configuration object
-        """
-        return instance_config.render_trash_metadata(trash_metadata_dir)
 
     def render(self, instance_config: Config) -> Config:
         """

--- a/buildarr/plugins/dummy/config/__init__.py
+++ b/buildarr/plugins/dummy/config/__init__.py
@@ -19,7 +19,6 @@ Dummy plugin configuration.
 
 from __future__ import annotations
 
-from pathlib import Path
 from typing import TYPE_CHECKING, Dict, Optional
 
 from typing_extensions import Self
@@ -149,29 +148,23 @@ class DummyInstanceConfig(_DummyInstanceConfig):
         """
         return self.settings.uses_trash_metadata
 
-    def render_trash_metadata(self, trash_metadata_dir: Path) -> Self:
+    def render(self) -> Self:
         """
-        Read TRaSH-Guides metadata, and return a configuration object with all templates rendered.
-
-        Args:
-            trash_metadata_dir (Path): TRaSH-Guides metadata directory.
+        Render dynamic configuration attributes, and return the resulting configuration object.
 
         Returns:
             Rendered configuration object
         """
         copy = self.copy(deep=True)
-        copy._render_trash_metadata(trash_metadata_dir)
+        copy._render()
         return copy
 
-    def _render_trash_metadata(self, trash_metadata_dir: Path) -> None:
+    def _render(self) -> None:
         """
-        Render configuration attributes obtained from TRaSH-Guides, in-place.
-
-        Args:
-            trash_metadata_dir (Path): TRaSH-Guides metadata directory.
+        Render dynamic configuration attributes in place.
         """
         if self.settings.uses_trash_metadata:
-            self.settings._render_trash_metadata(trash_metadata_dir)
+            self.settings._render()
 
     @classmethod
     def from_remote(cls, secrets: DummySecrets) -> Self:
@@ -211,34 +204,3 @@ class DummyConfig(DummyInstanceConfig):
     Globally specified configuration values apply to all instances.
     Configuration values specified on an instance-level take precedence at runtime.
     """
-
-    @property
-    def uses_trash_metadata(self) -> bool:
-        """
-        A flag determining whether or not this configuration uses TRaSH-Guides metadata.
-
-        Returns:
-            `True` if TRaSH-Guides metadata is used, otherwise `False`
-        """
-        for instance in self.instances.values():
-            if instance.uses_trash_metadata:
-                return True
-        return super().uses_trash_metadata
-
-    def render_trash_metadata(self, trash_metadata_dir: Path) -> Self:
-        """
-        Read TRaSH-Guides metadata, and return a configuration object with all templates rendered.
-
-        Args:
-            trash_metadata_dir (Path): TRaSH-Guides metadata directory.
-
-        Returns:
-            Rendered configuration object
-        """
-        copy = self.copy(deep=True)
-        for instance in copy.instances.values():
-            if instance.uses_trash_metadata:
-                instance._render_trash_metadata(trash_metadata_dir)
-        if self.uses_trash_metadata:
-            copy._render_trash_metadata(trash_metadata_dir)
-        return copy

--- a/buildarr/plugins/dummy/config/settings.py
+++ b/buildarr/plugins/dummy/config/settings.py
@@ -21,7 +21,6 @@ from __future__ import annotations
 
 import json
 
-from pathlib import Path
 from typing import Any, List, Mapping, Optional, Union, cast
 from uuid import UUID, uuid4
 
@@ -119,20 +118,20 @@ class DummySettingsConfig(DummyConfigBase):
         """
         return bool(self.trash_id)
 
-    def _render_trash_metadata(self, sonarr_metadata_dir: Path) -> None:
+    def _render(self) -> None:
         """
-        Render configuration attributes obtained from TRaSH-Guides, in-place.
+        Render dynamic configuration attributes in place.
+
+        Specifically, this function reads a value from the TRaSH-Guides metadata
+        and populates the `trash_value` attribute with it.
 
         Set `trash_value` to the minimum data rate value for the
         `Bluray-1080p` quality definition in the profile.
-
-        Args:
-            trash_metadata_dir (Path): TRaSH-Guides metadata directory.
         """
         if not self.trash_id:
             return
         for quality_file in (
-            sonarr_metadata_dir / "docs" / "json" / "sonarr" / "quality-size"
+            state.trash_metadata_dir / "docs" / "json" / "sonarr" / "quality-size"
         ).iterdir():
             with quality_file.open() as f:
                 quality_json: Mapping[str, Any] = json.load(f)

--- a/buildarr/trash.py
+++ b/buildarr/trash.py
@@ -19,7 +19,6 @@ Buildarr TRaSH-Guides metadata functions.
 
 from __future__ import annotations
 
-from collections import defaultdict
 from contextlib import contextmanager
 from logging import getLogger
 from pathlib import Path
@@ -32,9 +31,7 @@ from .state import state
 from .util import create_temp_dir
 
 if TYPE_CHECKING:
-    from typing import DefaultDict, Dict, Generator
-
-    from .config import ConfigPlugin
+    from typing import Generator
 
 
 logger = getLogger(__name__)
@@ -104,37 +101,3 @@ def fetch_trash_metadata() -> Generator[Path, None, None]:
 
         logger.debug("Deleting TRaSH metadata download temporary directory")
     logger.debug("Finished deleting TRaSH metadata download temporary directory")
-
-
-def render_trash_metadata(trash_metadata_dir: Path) -> None:
-    """
-    Render TRaSH-Guides metadata on any instance configurations where used,
-    and update the global state.
-
-    Plugins will parse the TRaSH-Guides metadata files in the given directory
-    and return new configuration objects with attributes populated from the metadata.
-
-    Instances that do not use TRaSH-Guides metadata will be left unchanged.
-
-    Args:
-        trash_metadata_dir (Path): Local folder containing TRaSH-Guides metadata files.
-    """
-
-    instance_configs: DefaultDict[str, Dict[str, ConfigPlugin]] = defaultdict(dict)
-
-    for plugin_name, instance_name in state._execution_order:
-        manager = state.managers[plugin_name]
-        instance_config = state.instance_configs[plugin_name][instance_name]
-        with state._with_context(plugin_name=plugin_name, instance_name=instance_name):
-            if manager.uses_trash_metadata(instance_config):
-                logger.debug("Rendering TRaSH-Guides metadata")
-                instance_configs[plugin_name][instance_name] = manager.render_trash_metadata(
-                    instance_config,
-                    trash_metadata_dir,
-                )
-                logger.debug("Finished rendering TRaSH-Guides metadata")
-            else:
-                logger.debug("Skipping rendering TRaSH-Guides metadata (not used)")
-                instance_configs[plugin_name][instance_name] = instance_config
-
-    state.instance_configs = instance_configs

--- a/buildarr/types.py
+++ b/buildarr/types.py
@@ -22,6 +22,7 @@ from __future__ import annotations
 import re
 
 from enum import Enum
+from functools import total_ordering
 from pathlib import Path, PurePosixPath, PureWindowsPath
 from typing import TYPE_CHECKING, Any, Callable, Generator, Mapping
 
@@ -217,6 +218,7 @@ class BaseEnum(Enum):
                 raise ValueError(f"Invalid {cls.__name__} name or value: {value}") from None
 
 
+@total_ordering
 class DayOfWeek(BaseEnum):
     """
     Sortable eumeration for the days in the week (Monday to Sunday).
@@ -239,6 +241,41 @@ class DayOfWeek(BaseEnum):
     friday = 4
     saturday = 5
     sunday = 6
+
+    def __eq__(self, other: Any) -> bool:
+        """
+        Reimplement tha `a == b` operator for `DayOfWeek`, so integers
+        of the same value also get evaluated as equal.
+
+        Args:
+            other (Any): Object to check is equal to this object.
+
+        Returns:
+            `True` if this object is equal to `other`, otherwise `False`
+        """
+        try:
+            other_obj = DayOfWeek(other)
+        except ValueError:
+            raise NotImplementedError() from None
+        return self.value == other_obj.value
+
+    def __lt__(self, other: Any) -> bool:
+        """
+        Implement the `a < b` operator for `DayOfWeek`.
+
+        The `total_ordering` decorator will declare the rest.
+
+        Args:
+            other (Any): Object to check is greater than this object.
+
+        Returns:
+            `True` if this object is less than `other`, otherwise `False`
+        """
+        try:
+            other_obj = DayOfWeek(other)
+        except ValueError:
+            raise NotImplementedError() from None
+        return self.value < other_obj.value
 
 
 class InstanceName(str):

--- a/buildarr/types.py
+++ b/buildarr/types.py
@@ -20,9 +20,8 @@ Buildarr general purpose type hints, used in plugin models.
 from __future__ import annotations
 
 import re
-import warnings
 
-from enum import Enum, IntEnum
+from enum import Enum
 from pathlib import Path, PurePosixPath, PureWindowsPath
 from typing import TYPE_CHECKING, Any, Callable, Generator, Mapping
 
@@ -218,85 +217,7 @@ class BaseEnum(Enum):
                 raise ValueError(f"Invalid {cls.__name__} name or value: {value}") from None
 
 
-class BaseIntEnum(IntEnum):
-    """
-    Integer numeration base class for use in Buildarr configurations.
-
-    Like `BaseEnum`, but as the enumeration values are guaranteed to be integer type,
-    it natively supports sorting functions such as `sorted`.
-    """
-
-    @classmethod
-    def from_name_str(cls, name_str: str) -> Self:
-        """
-        Get the enumeration object corresponding to the given name case-insensitively.
-
-        Args:
-            name_str (str): Name of the enumeration value (case insensitive).
-
-        Raises:
-            KeyError: When the enumeration name is invalid (does not exist).
-
-        Returns:
-            The enumeration object for the given name
-        """
-        warnings.warn(
-            (
-                "BaseIntEnum is deprecated, and will be removed in Buildarr version 0.5.0. "
-                "Please update your Buildarr plugin to use BaseEnum instead."
-            ),
-            DeprecationWarning,
-            stacklevel=1,
-        )
-        name = name_str.lower().replace("-", "_")
-        for obj in cls:
-            if obj.name.lower() == name:
-                return obj
-        raise KeyError(repr(name))
-
-    def to_name_str(self) -> str:
-        """
-        Return the name for this enumaration object.
-
-        Returns:
-            Enumeration name
-        """
-        return self.name.replace("_", "-")
-
-    @classmethod
-    def __get_validators__(cls) -> Generator[Callable[[Any], Self], None, None]:
-        """
-        Pass class validation functions to Pydantic.
-
-        Yields:
-            Validation class functions
-        """
-        yield cls.validate
-
-    @classmethod
-    def validate(cls, value: Any) -> Self:
-        """
-        Validate and coerce the given value to an enumeration object.
-
-        Args:
-            value (Any): Object to validate and coerce
-
-        Raises:
-            ValueError: If a enumeration object corresponding with the value cannot be found
-
-        Returns:
-            Enumeration object corresponding to the given value
-        """
-        try:
-            return cls(value)
-        except ValueError:
-            try:
-                return cls.from_name_str(value)
-            except (TypeError, KeyError):
-                raise ValueError(f"Invalid {cls.__name__} name or value: {value}") from None
-
-
-class DayOfWeek(BaseIntEnum):
+class DayOfWeek(BaseEnum):
     """
     Sortable eumeration for the days in the week (Monday to Sunday).
 

--- a/buildarr/types.py
+++ b/buildarr/types.py
@@ -244,7 +244,7 @@ class DayOfWeek(BaseEnum):
 
     def __eq__(self, other: Any) -> bool:
         """
-        Reimplement tha `a == b` operator for `DayOfWeek`, so integers
+        Reimplement the `a == b` operator for `DayOfWeek`, so integers
         of the same value also get evaluated as equal.
 
         Args:
@@ -258,6 +258,17 @@ class DayOfWeek(BaseEnum):
         except ValueError:
             raise NotImplementedError() from None
         return self.value == other_obj.value
+
+    def __hash__(self) -> int:
+        """
+        Implement the hash method for `DayOfWeek`.
+
+        Simply return the enumeration value, since it is an integer and always unique.
+
+        Returns:
+            `DayOfWeek` hash
+        """
+        return self.value
 
     def __lt__(self, other: Any) -> bool:
         """


### PR DESCRIPTION
* Remove the deprecated `BaseIntEnum` configuration/secrets attribute type
    * Reimplement the only internal usage of this, `DayOfWeek`, as a regular `BaseEnum` that is sortable
* Remove the deprecated `render_trash_metadata` run stage 