### PR TITLE
Remove the deprecated ad-hoc run `--dry-run` option

### DIFF
--- a/README.md
+++ b/README.md
@@ -177,7 +177,6 @@ For more information on how to interfact with Buildarr, check the [usage documen
 
 ## To-do list
 
-* Add a dry-run mode for testing configurations (added in [version 0.4.0](https://buildarr.github.io/release-notes/#v040-2023-03-31))
 * Test updates for all available attributes in the existing Sonarr plugin
 * Unit tests and code coverage
 * Split Sonarr plugin to its own repository (completed in [version 0.4.0](https://buildarr.github.io/release-notes/#v040-2023-03-31))

--- a/buildarr/cli/run.py
+++ b/buildarr/cli/run.py
@@ -92,14 +92,6 @@ logger = getLogger(__name__)
     ),
 )
 @click.option(
-    "-D",
-    "--dry-run",
-    "dry_run",
-    is_flag=True,
-    default=False,
-    help="Enable dry-run mode. Update runs are executed, but instances are not modified.",
-)
-@click.option(
     "-p",
     "--plugin",
     "use_plugins",
@@ -115,7 +107,6 @@ logger = getLogger(__name__)
 def run(
     config_path: Path,
     secrets_file_path: Optional[Path],
-    dry_run: bool,
     use_plugins: Set[str],
 ) -> None:
     """
@@ -123,17 +114,10 @@ def run(
 
     Args:
         config_path (Path): Configuration file to load.
-        dry_run (bool): If set to `True`, run in dry-run mode.
         plugins (Set[str]): Plugins to load. If empty, use all plugins.
     """
 
     logger.info("Buildarr version %s (log level: %s)", __version__, get_log_level())
-
-    if dry_run:
-        logger.info(
-            "Dry-run mode enabled: executing update runs, but will not modify instances",
-        )
-        state.dry_run = True
 
     logger.info("Loading configuration file '%s'", config_path)
     load_config(path=config_path, use_plugins=use_plugins)

--- a/buildarr/cli/test_config.py
+++ b/buildarr/cli/test_config.py
@@ -54,8 +54,6 @@ logger = getLogger(__name__)
         "This loads the configuration file and performs a number of checks on it. "
         "If all tests pass, the file is pretty much guaranteed to work properly "
         "in a Buildarr run, incorrect values for a remote instance notwithstanding.\n\n"
-        "To validate the configuration against remote instances without modifying them, "
-        "use `buildarr run --dry-run'.\n\n"
         "If CONFIG-PATH is not defined, use `buildarr.yml' from the current directory."
     ),
 )

--- a/buildarr/plugins/dummy/config/types.py
+++ b/buildarr/plugins/dummy/config/types.py
@@ -30,9 +30,9 @@ if TYPE_CHECKING:
     from ..secrets import DummySecrets
 
     class DummyConfigBase(ConfigBase[DummySecrets]):
-        ...
+        pass
 
 else:
 
     class DummyConfigBase(ConfigBase):
-        ...
+        pass

--- a/buildarr/plugins/dummy/exceptions.py
+++ b/buildarr/plugins/dummy/exceptions.py
@@ -19,12 +19,7 @@ Dummy plugin exception classes.
 
 from __future__ import annotations
 
-from typing import TYPE_CHECKING
-
 from buildarr.exceptions import BuildarrError
-
-if TYPE_CHECKING:
-    from requests import Response
 
 
 class DummyError(BuildarrError):
@@ -40,6 +35,22 @@ class DummyAPIError(DummyError):
     Dummy API exception class.
     """
 
-    def __init__(self, msg: str, response: Response) -> None:
-        self.response = response
+    def __init__(self, msg: str, status_code: int) -> None:
+        self.status_code = status_code
         super().__init__(msg)
+
+
+class DummySecretsError(DummyError):
+    """
+    Dummy plugin secrets exception base class.
+    """
+
+    pass
+
+
+class DummySecretsUnauthorizedError(DummySecretsError):
+    """
+    Error raised when the Dummy API key wasn't able to be retrieved.
+    """
+
+    pass

--- a/buildarr/state.py
+++ b/buildarr/state.py
@@ -59,15 +59,15 @@ class State:
     Whether Buildarr is in testing mode or not.
     """
 
-    dry_run: bool = False
-    """
-    Whether Buildarr is in dry run mode or not.
+    @property
+    def dry_run(self) -> bool:
+        """
+        Whether Buildarr is in dry run mode or not.
 
-    When set to `True` under a CLI command that supports it, the command should not
-    perform any action that would change the state of any external instances.
-
-    Custom CLI commands can set this attribute to `True` if they support a dry-run mode.
-    """
+        **Note: As of Buildarr v0.5.0, this mode is no longer available,
+        and `state.dry_run` will always return `False`.**
+        """
+        return False
 
     plugins: Mapping[str, Plugin] = {}
     """

--- a/docs/index.md
+++ b/docs/index.md
@@ -181,7 +181,6 @@ For more information on how to interfact with Buildarr, check the [usage documen
 
 ## To-do list
 
-* Add a dry-run mode for testing configurations (added in [version 0.4.0](release-notes.md#v040-2023-03-31))
 * Test updates for all available attributes in the existing Sonarr plugin
 * Unit tests and code coverage
 * Split Sonarr plugin to its own repository (completed in [version 0.4.0](release-notes.md#v040-2023-03-31))

--- a/docs/release-notes.md
+++ b/docs/release-notes.md
@@ -80,7 +80,7 @@ After Buildarr releases its first stable version (`v1.0.0`), major version incre
 
 A number of other features and bugfixes have been added in this release:
 
-* Add support for [dry runs](usage.md#dry-runs) in Buildarr ad-hoc runs, for testing configuration changes against live instances *without* modifying them
+* Add support for dry runs in Buildarr ad-hoc runs, for testing configuration changes against live instances *without* modifying them
 * Add [configuration validity testing](usage.md#testing-configuration) using the `buildarr test-config` command
 * Add support for [overriding the secrets file](configuration.md#buildarr.config.buildarr.BuildarrConfig.secrets_file_path) path using the `--secrets-file` option
 * Add [automatic generation of Docker Compose files](usage.md#generating-a-docker-compose-file) from Buildarr configuration files using the `buildarr compose` command

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -107,17 +107,7 @@ When Buildarr detects that the remote configuration differs from the locally def
 
 If the run fails for one reason or another, an error message will be logged and Buildarr will exit with a non-zero status code.
 
-### Dry runs
-
-*New in version 0.4.0.*
-
-Buildarr ad-hoc runs support a dry-run mode, so you can check what *would* change on configured instances, before actually applying them. Under this mode, the output of Buildarr itself is almost exactly the same, but any actions logged in the output are not actually performed.
-
-```bash
-$ buildarr run --dry-run
-```
-
-This allows you to test changes in the configuration, or check the current state of remote instances against the configuration before actually committing changes.
+*Changed in version 0.5.0*: Dry runs have been removed from Buildarr. If [testing your configuration](#testing-configuration) does not cover your needs, consider creating a staging environment for your Arr stack, and test changes there before rolling it out to your production stack.
 
 ## As a service (daemon mode)
 
@@ -216,8 +206,6 @@ $ buildarr test-config /config/buildarr.yml
 ```
 
 Since Buildarr does not connect to any remote instances in this mode, even if a configuration file passes the tests performed by `buildarr test-config`, it will not necessarily successfully communicate with them.
-
-To test the configuration against live remote instances, without modifying them, you can use `buildarr run --dry-run` as documented in [Dry runs](#dry-runs).
 
 ## Generating a Docker Compose file
 


### PR DESCRIPTION
* Remove the `--dry-run` CLI option from `buildarr run`
* Change `state.dry_run` to be a fixed property that always returns `False`
* Remove all usage of `state.dry_run` within Buildarr itself
* Update the Dummy plugin to the newer API function code from the Jellyseerr plugin