### PR TITLE
Set `validate_assignment` to `True` by default for config models

### DIFF
--- a/buildarr/plugins/dummy/config/settings.py
+++ b/buildarr/plugins/dummy/config/settings.py
@@ -217,8 +217,3 @@ class DummySettingsConfig(DummyConfigBase):
             api_post(secrets, "/api/v1/settings", remote_attrs)
             return True
         return False
-
-    class Config(DummyConfigBase.Config):
-        # Ensure in-place assignments of attributes are always validated,
-        # since this class performs such modifications in certain cases.
-        validate_assignment = True

--- a/buildarr/secrets/base.py
+++ b/buildarr/secrets/base.py
@@ -92,6 +92,4 @@ class SecretsBase(BaseModel, Generic[Config]):
         ```
         """
 
-        # Validate any values that have been modified in-place, to ensure the model
-        # still fits the constraints.
-        validate_assignment = True
+        pass

--- a/buildarr/types.py
+++ b/buildarr/types.py
@@ -483,3 +483,7 @@ class ModelConfigBase:
     # (For example, a normally optional attribute becoming required due to
     # another attribute being enabled.)
     validate_all = True
+
+    # Validate any values that have been modified in-place, to ensure the model
+    # still fits the constraints.
+    validate_assignment = True


### PR DESCRIPTION
This removes the need to manually define `validate_assignment = True` on any configuration object that in-place modifies its own attributes at any point.