### PR TITLE
Change `ConfigBase.uses_trash_metadata` to a function

### DIFF
--- a/buildarr/config/models.py
+++ b/buildarr/config/models.py
@@ -126,14 +126,14 @@ class ConfigPlugin(ConfigBase[Secrets]):
         """
         return f"{self.protocol}://{self.hostname}:{self.port}"
 
-    @property
     def uses_trash_metadata(self) -> bool:
         """
-        A flag determining whether or not this configuration uses TRaSH-Guides metadata.
+        Return whether or not this instance configuration uses TRaSH-Guides metadata.
 
-        Configuration plugins should implement this property if TRaSH-Guides metadata is used.
+        Configuration plugins should implement this function if TRaSH-Guides metadata is used.
 
-        This property is checked by the `ManagerPlugin.uses_trash_metadata()` function.
+        Returns:
+            `True` if TRaSH-Guides metadata is used, otherwise `False`
         """
         return False
 

--- a/buildarr/manager/__init__.py
+++ b/buildarr/manager/__init__.py
@@ -86,7 +86,7 @@ class ManagerPlugin(Generic[Config, Secrets]):
         Returns:
             `True` if TRaSH-Guides metadata is used, otherwise `False`
         """
-        return instance_config.uses_trash_metadata
+        return instance_config.uses_trash_metadata()
 
     def render(self, instance_config: Config) -> Config:
         """

--- a/buildarr/plugins/dummy/config/__init__.py
+++ b/buildarr/plugins/dummy/config/__init__.py
@@ -138,15 +138,14 @@ class DummyInstanceConfig(_DummyInstanceConfig):
     Configuration options for Dummy itself are set within this structure.
     """
 
-    @property
     def uses_trash_metadata(self) -> bool:
         """
-        A flag determining whether or not this instance configuration uses TRaSH-Guides metadata.
+        Return whether or not this instance configuration uses TRaSH-Guides metadata.
 
         Returns:
             `True` if TRaSH-Guides metadata is used, otherwise `False`
         """
-        return self.settings.uses_trash_metadata
+        return self.settings.uses_trash_metadata()
 
     def render(self) -> Self:
         """
@@ -155,6 +154,8 @@ class DummyInstanceConfig(_DummyInstanceConfig):
         Returns:
             Rendered configuration object
         """
+        if not self.settings.uses_trash_metadata():
+            return self
         copy = self.copy(deep=True)
         copy._render()
         return copy
@@ -163,8 +164,7 @@ class DummyInstanceConfig(_DummyInstanceConfig):
         """
         Render dynamic configuration attributes in place.
         """
-        if self.settings.uses_trash_metadata:
-            self.settings._render()
+        self.settings._render()
 
     @classmethod
     def from_remote(cls, secrets: DummySecrets) -> Self:

--- a/buildarr/plugins/dummy/config/settings.py
+++ b/buildarr/plugins/dummy/config/settings.py
@@ -108,10 +108,9 @@ class DummySettingsConfig(DummyConfigBase):
     * `ConfigBase.get_update_remote_attrs`
     """
 
-    @property
     def uses_trash_metadata(self) -> bool:
         """
-        A flag determining whether or not this instance configuration uses TRaSH-Guides metadata.
+        Return whether or not this instance configuration uses TRaSH-Guides metadata.
 
         Returns:
             `True` if TRaSH-Guides metadata is used, otherwise `False`


### PR DESCRIPTION
* Change `ConfigBase.uses_trash_metadata` from a dynamically generated property to a function
* Update the Dummy plugin to reflect the change