### PR TITLE
Add post-initialisation rendering step

### DIFF
--- a/buildarr/config/__init__.py
+++ b/buildarr/config/__init__.py
@@ -23,6 +23,7 @@ from .base import ConfigBase
 from .exceptions import ConfigError, ConfigTrashIDNotFoundError
 from .load import load_config, load_instance_configs
 from .models import ConfigPlugin, ConfigPluginType, ConfigType
+from .post_init_render import post_init_render
 from .render_instance_configs import render_instance_configs
 from .resolve_instance_dependencies import resolve_instance_dependencies
 from .types import RemoteMapEntry
@@ -37,6 +38,7 @@ __all__ = [
     "RemoteMapEntry",
     "load_config",
     "load_instance_configs",
+    "post_init_render",
     "resolve_instance_dependencies",
     "render_instance_configs",
 ]

--- a/buildarr/config/models.py
+++ b/buildarr/config/models.py
@@ -229,6 +229,30 @@ class ConfigPlugin(ConfigBase[Secrets]):
         """
         raise NotImplementedError()
 
+    def post_init_render(self, secrets: Secrets) -> Self:
+        """
+        Render dynamically populated configuration attributes that require the instance
+        to be initialised.
+
+        Typically used for fetching configuration attribute schemas from the remote instance
+        for validation during rendering.
+
+        If the instance configuration returned `True` for `uses_trash_metadata`,
+        the filepath to the downloaded metadata directory will be available as
+        `state.trash_metadata_dir` in the global state.
+
+        Configuration plugins should implement this function if there are any attributes
+        that get dynamically populated, but require some kind of request to be made to the
+        remote instance during the rendering process.
+
+        Args:
+            secrets (Secrets): Remote instance host and secrets information.
+
+        Returns:
+            Rendered configuration object
+        """
+        raise NotImplementedError()
+
     def to_compose_service(self, compose_version: str, service_name: str) -> Dict[str, Any]:
         """
         Generate a Docker Compose service definition corresponding to this instance configuration.

--- a/buildarr/config/post_init_render.py
+++ b/buildarr/config/post_init_render.py
@@ -13,7 +13,7 @@
 
 
 """
-Buildarr configuration rendering function.
+Post-initialisation configuration rendering stage.
 """
 
 

--- a/buildarr/config/post_init_render.py
+++ b/buildarr/config/post_init_render.py
@@ -1,0 +1,60 @@
+# Copyright (C) 2023 Callum Dickinson
+#
+# Buildarr is free software: you can redistribute it and/or modify it under the terms of the
+# GNU General Public License as published by the Free Software Foundation,
+# either version 3 of the License, or (at your option) any later version.
+#
+# Buildarr is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY;
+# without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+# See the GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License along with Buildarr.
+# If not, see <https://www.gnu.org/licenses/>.
+
+
+"""
+Buildarr configuration rendering function.
+"""
+
+
+from __future__ import annotations
+
+from collections import defaultdict
+from logging import getLogger
+from typing import TYPE_CHECKING
+
+from ..state import state
+
+if TYPE_CHECKING:
+    from typing import DefaultDict, Dict
+
+    from .models import ConfigPlugin
+
+logger = getLogger(__name__)
+
+
+def post_init_render() -> None:
+    """
+    Render dynamically populated attributes on instance configurations,
+    and update the global state.
+
+    If an instance configuration returned `True` for `uses_trash_metadata`,
+    the filepath to the downloaded metadata directory will be available as
+    `state.trash_metadata_dir` in the global state.
+    """
+
+    instance_configs: DefaultDict[str, Dict[str, ConfigPlugin]] = defaultdict(dict)
+
+    for plugin_name, instance_name in state._execution_order:
+        manager = state.managers[plugin_name]
+        instance_config = state.instance_configs[plugin_name][instance_name]
+        with state._with_context(plugin_name=plugin_name, instance_name=instance_name):
+            instance_secrets = getattr(state.secrets, plugin_name)[instance_name]
+            logger.debug("Rendering post-initialisation configuration rendering")
+            instance_configs[plugin_name][instance_name] = manager.post_init_render(
+                instance_config,
+                instance_secrets,
+            )
+            logger.debug("Finished post-initialisation configuration rendering")
+
+    state.instance_configs = instance_configs

--- a/buildarr/manager/__init__.py
+++ b/buildarr/manager/__init__.py
@@ -136,6 +136,27 @@ class ManagerPlugin(Generic[Config, Secrets]):
         """
         instance_config.initialize(tree)
 
+    def post_init_render(self, instance_config: Config, secrets: Secrets) -> Config:
+        """
+        Render dynamically populated configuration attributes that require the instance
+        to be initialised.
+
+        Typically used for fetching configuration attribute schemas from the remote instance
+        for validation during rendering.
+
+        If the instance configuration returned `True` for `uses_trash_metadata`,
+        the filepath to the downloaded metadata directory will be available as
+        `state.trash_metadata_dir` in the global state.
+
+        Args:
+            instance_config (Config): Instance configuration object to render.
+            secrets (Secrets): Remote instance host and secrets information.
+
+        Returns:
+            Rendered configuration object
+        """
+        return instance_config.post_init_render(secrets)
+
     def from_remote(self, instance_config: Config, secrets: Secrets) -> Config:
         """
         Get the active configuration for a remote instance, and return the resulting object.

--- a/buildarr/util.py
+++ b/buildarr/util.py
@@ -23,7 +23,8 @@ import os
 
 from contextlib import contextmanager
 from pathlib import Path
-from tempfile import TemporaryDirectory
+from shutil import rmtree
+from tempfile import TemporaryDirectory, mkdtemp
 from typing import TYPE_CHECKING, Mapping
 
 if TYPE_CHECKING:
@@ -112,7 +113,7 @@ def merge_dicts(*dicts: Mapping[Any, Any]) -> Dict[Any, Any]:
 
 
 @contextmanager
-def create_temp_dir(prefix: str = "buildarr.", **kwargs) -> Generator[Path, None, None]:
+def temp_dir(prefix: str = "buildarr.", **kwargs) -> Generator[Path, None, None]:
     """
     Create a temporary directory, give access to it for the executing context,
     and clean up the directory upon exit from the context.
@@ -128,3 +129,34 @@ def create_temp_dir(prefix: str = "buildarr.", **kwargs) -> Generator[Path, None
 
     with TemporaryDirectory(prefix=prefix, **kwargs) as temp_dir_str:
         yield Path(temp_dir_str)
+
+
+def create_temp_dir(prefix: str = "buildarr.", **kwargs) -> Path:
+    """
+    Create a temporary directory, and return it without any additional handling.
+
+    The caller is trusted to clean up the directory once it is no longer needed.
+
+    Args:
+        prefix (str, optional): Temporary directory name prefix. Defaults to `buildarr.`.
+
+    Returns:
+        Temporary directory path
+    """
+
+    return Path(mkdtemp(prefix=prefix, **kwargs))
+
+
+def remove_dir(path: os.PathLike, nonexist_ok: bool = True) -> None:
+    """
+    Delete a temporary directory and all containing files.
+
+    Args:
+        nonexist_ok (bool, optional): Return OK if the directory doesn't exist. Defaults to `true`.
+    """
+
+    try:
+        rmtree(path)
+    except FileNotFoundError:
+        if not nonexist_ok:
+            raise


### PR DESCRIPTION
Useful for dynamic configuration that requires the remote instance to be accessible for rendering, e.g. value-to-name resolution, instance links.