### PR TITLE
Detect plugins that do not use config rendering

### DIFF
--- a/buildarr/config/models.py
+++ b/buildarr/config/models.py
@@ -192,8 +192,11 @@ class ConfigPlugin(ConfigBase[Secrets]):
 
         Returns:
             Rendered configuration object
+
+        Raises:
+            NotImplementedError: When pre-initialisation rendering is not supported.
         """
-        return self
+        raise NotImplementedError()
 
     def is_initialized(self) -> bool:
         """
@@ -205,11 +208,11 @@ class ConfigPlugin(ConfigBase[Secrets]):
         Configuration plugins should implement this function if initialisation is required
         for the application's API to become available.
 
-        Raises:
-            NotImplementedError: When initialisation is not required for the application type.
-
         Returns:
             `True` if the instance is initialised, otherwise `False`
+
+        Raises:
+            NotImplementedError: When initialisation is not supported for the application type.
         """
         raise NotImplementedError()
 
@@ -226,6 +229,9 @@ class ConfigPlugin(ConfigBase[Secrets]):
 
         Args:
             tree (str): Configuration tree this instance falls under (for logging purposes).
+
+        Raises:
+            NotImplementedError: When initialisation is not supported for the application type.
         """
         raise NotImplementedError()
 
@@ -250,6 +256,9 @@ class ConfigPlugin(ConfigBase[Secrets]):
 
         Returns:
             Rendered configuration object
+
+        Raises:
+            NotImplementedError: When post-initialisation rendering is not supported.
         """
         raise NotImplementedError()
 

--- a/buildarr/config/post_init_render.py
+++ b/buildarr/config/post_init_render.py
@@ -50,11 +50,20 @@ def post_init_render() -> None:
         instance_config = state.instance_configs[plugin_name][instance_name]
         with state._with_context(plugin_name=plugin_name, instance_name=instance_name):
             instance_secrets = getattr(state.secrets, plugin_name)[instance_name]
-            logger.debug("Rendering post-initialisation configuration rendering")
-            instance_configs[plugin_name][instance_name] = manager.post_init_render(
-                instance_config,
-                instance_secrets,
-            )
-            logger.debug("Finished post-initialisation configuration rendering")
+            logger.debug("Performing post-initialisation configuration rendering")
+            try:
+                instance_configs[plugin_name][instance_name] = manager.post_init_render(
+                    instance_config,
+                    instance_secrets,
+                )
+            except NotImplementedError:
+                logger.debug(
+                    (
+                        "Skipped performing post-initialisation configuration rendering "
+                        "(not supported by plugin)"
+                    ),
+                )
+            else:
+                logger.debug("Finished performing post-initialisation configuration rendering")
 
     state.instance_configs = instance_configs

--- a/buildarr/config/render_instance_configs.py
+++ b/buildarr/config/render_instance_configs.py
@@ -49,8 +49,17 @@ def render_instance_configs() -> None:
         manager = state.managers[plugin_name]
         instance_config = state.instance_configs[plugin_name][instance_name]
         with state._with_context(plugin_name=plugin_name, instance_name=instance_name):
-            logger.debug("Rendering dynamic configuration attributes")
-            instance_configs[plugin_name][instance_name] = manager.render(instance_config)
-            logger.debug("Finished dynamic configuration attributes")
+            logger.debug("Performing pre-initialisation configuration rendering")
+            try:
+                instance_configs[plugin_name][instance_name] = manager.render(instance_config)
+            except NotImplementedError:
+                logger.debug(
+                    (
+                        "Skipped performing re-initialisation configuration rendering "
+                        "(not supported by plugin)"
+                    ),
+                )
+            else:
+                logger.debug("Finished performing pre-initialisation configuration rendering")
 
     state.instance_configs = instance_configs


### PR DESCRIPTION
Distinguish between plugins that do not support configuration rendering, and those that do, by raising `NotImplementedError` in the former case. Make sure both cases are properly handled.

Post-initialisation rendering already had this change made in the previous PR, but did not have the correct error handling. This PR addresses that.