### PR TITLE
Improve daemon reloading

### DIFF
--- a/buildarr/cli/daemon.py
+++ b/buildarr/cli/daemon.py
@@ -398,7 +398,7 @@ class ConfigDirEventHandler(FileSystemEventHandler):
             logger.exception(
                 (
                     "Unexpected exception occurred "
-                    f"while handling config file recreation event: %s"
+                    "while handling config file recreation event: %s"
                 ),
                 err,
             )
@@ -421,7 +421,7 @@ class ConfigDirEventHandler(FileSystemEventHandler):
             logger.exception(
                 (
                     "Unexpected exception occurred "
-                    f"while handling config file modification event: %s"
+                    "while handling config file modification event: %s"
                 ),
                 err,
             )

--- a/buildarr/cli/daemon.py
+++ b/buildarr/cli/daemon.py
@@ -282,10 +282,13 @@ class Daemon:
         If disabled and was previously enabled, stop configuration watching.
         """
         if self._watch_config == self._old_watch_config:
-            logger.debug("Skipped setting up config file monitoring (disabled)")
+            logger.info(
+                "Config file monitoring is already %s",
+                "enabled" if self._watch_config else "disabled",
+            )
             return
         if self._watch_config:
-            logger.info("Setting up config file monitoring")
+            logger.info("Enabling config file monitoring")
             self._observer = PollingObserver()
             config_dirs: Dict[Path, Set[str]] = {}
             for config_file in state.config_files:
@@ -304,7 +307,7 @@ class Daemon:
                 )
             logger.debug("Starting config file observer")
             self._observer.start()
-            logger.info("Finished setting up config file monitoring")
+            logger.info("Finished enabling config file monitoring")
         else:
             logger.info("Disabling config file monitoring")
             self._observer.stop()

--- a/buildarr/cli/daemon.py
+++ b/buildarr/cli/daemon.py
@@ -111,7 +111,7 @@ class Daemon:
         """
         with self._run_lock():
             self._initial_run()
-            self._start_signal_handlers()
+            self._setup_signal_handlers()
             self._log_next_run()
             logger.info("Buildarr ready.")
         # Enter the update job schedule main loop.
@@ -334,7 +334,7 @@ class Daemon:
             finally:
                 logger.info("Buildarr ready.")
 
-    def _start_signal_handlers(self) -> None:
+    def _setup_signal_handlers(self) -> None:
         """
         Setup `SIGINT`, `SIGTERM` and `SIGHUP` signal handers.
 

--- a/buildarr/cli/daemon.py
+++ b/buildarr/cli/daemon.py
@@ -282,6 +282,7 @@ class Daemon:
         If disabled and was previously enabled, stop configuration watching.
         """
         if self._watch_config == self._old_watch_config:
+            logger.debug("Skipped setting up config file monitoring (disabled)")
             return
         if self._watch_config:
             logger.info("Setting up config file monitoring")

--- a/buildarr/cli/daemon.py
+++ b/buildarr/cli/daemon.py
@@ -236,7 +236,7 @@ class Daemon:
         if self._watch_config:
             logger.info(" - Configuration files to watch:")
             for config_file in state.config_files:
-                logger.info("   - %s", str(config_file))
+                logger.info("   - %s", config_file)
         logger.info(" - Update at:")
         for update_day, update_time in self._update_daytimes:
             logger.info("   - %s %s", update_day.name.capitalize(), update_time.strftime("%H:%M"))
@@ -298,20 +298,23 @@ class Daemon:
             for config_dir, filenames in config_dirs.items():
                 logger.debug(
                     "Scheduling event handler for directory '%s' with config files %s",
-                    str(config_dir),
+                    config_dir,
                     ", ".join(repr(filename) for filename in filenames),
                 )
                 self._observer.schedule(
                     ConfigDirEventHandler(self, config_dir, filenames),
                     config_dir,
                 )
+                logger.debug("Finished scheduling event handler for directory '%s'", config_dir)
             logger.debug("Starting config file observer")
             self._observer.start()
+            logger.debug("Finished starting config file observer")
             logger.info("Finished enabling config file monitoring")
         else:
             logger.info("Disabling config file monitoring")
             self._observer.stop()
             self._observer = PollingObserver()
+            logger.info("Finished disabling config file monitoring")
 
     def _start_signal_handlers(self) -> None:
         # Setup SIGINT, SIGTERM, and SIGHUP signal handers.

--- a/buildarr/cli/daemon.py
+++ b/buildarr/cli/daemon.py
@@ -388,11 +388,20 @@ class ConfigDirEventHandler(FileSystemEventHandler):
         Args:
             event (Union[DirModifiedEvent, FileModifiedEvent]): Event metadata
         """
-        if not event.is_directory and Path(event.src_path) in (
-            (self.config_dir / filename) for filename in self.filenames
-        ):
-            logger.info("Config file '%s' has been recreated", event.src_path)
-            self.daemon.reload()
+        try:
+            if not event.is_directory and Path(event.src_path) in (
+                (self.config_dir / filename) for filename in self.filenames
+            ):
+                logger.info("Config file '%s' has been recreated", event.src_path)
+                self.daemon.reload()
+        except Exception as err:
+            logger.exception(
+                (
+                    "Unexpected exception occurred "
+                    f"while handling config file recreation event: %s"
+                ),
+                err,
+            )
 
     def on_modified(self, event: Union[DirModifiedEvent, FileModifiedEvent]) -> None:
         """
@@ -402,11 +411,20 @@ class ConfigDirEventHandler(FileSystemEventHandler):
         Args:
             event (Union[DirModifiedEvent, FileModifiedEvent]): Event metadata
         """
-        if not event.is_directory and Path(event.src_path) in (
-            (self.config_dir / filename) for filename in self.filenames
-        ):
-            logger.info("Config file '%s' has been modified", event.src_path)
-            self.daemon.reload()
+        try:
+            if not event.is_directory and Path(event.src_path) in (
+                (self.config_dir / filename) for filename in self.filenames
+            ):
+                logger.info("Config file '%s' has been modified", event.src_path)
+                self.daemon.reload()
+        except Exception as err:
+            logger.exception(
+                (
+                    "Unexpected exception occurred "
+                    f"while handling config file modification event: %s"
+                ),
+                err,
+            )
 
 
 def parse_time(

--- a/buildarr/cli/daemon.py
+++ b/buildarr/cli/daemon.py
@@ -387,11 +387,13 @@ class ConfigDirEventHandler(FileSystemEventHandler):
         Args:
             event (Union[DirModifiedEvent, FileModifiedEvent]): Event metadata
         """
+        buildarr_ran = False
         try:
             if not event.is_directory and Path(event.src_path) in (
                 (self.config_dir / filename) for filename in self.filenames
             ):
                 logger.info("Config file '%s' has been recreated", event.src_path)
+                buildarr_ran = True
                 self.daemon.reload()
         except Exception as err:
             logger.exception(
@@ -402,7 +404,8 @@ class ConfigDirEventHandler(FileSystemEventHandler):
                 err,
             )
         finally:
-            logger.info("Buildarr ready.")
+            if buildarr_ran:
+                logger.info("Buildarr ready.")
 
     def on_modified(self, event: Union[DirModifiedEvent, FileModifiedEvent]) -> None:
         """
@@ -412,11 +415,13 @@ class ConfigDirEventHandler(FileSystemEventHandler):
         Args:
             event (Union[DirModifiedEvent, FileModifiedEvent]): Event metadata
         """
+        buildarr_ran = False
         try:
             if not event.is_directory and Path(event.src_path) in (
                 (self.config_dir / filename) for filename in self.filenames
             ):
                 logger.info("Config file '%s' has been modified", event.src_path)
+                buildarr_ran = True
                 self.daemon.reload()
         except Exception as err:
             logger.exception(
@@ -427,7 +432,8 @@ class ConfigDirEventHandler(FileSystemEventHandler):
                 err,
             )
         finally:
-            logger.info("Buildarr ready.")
+            if buildarr_ran:
+                logger.info("Buildarr ready.")
 
 
 def parse_time(

--- a/buildarr/cli/daemon.py
+++ b/buildarr/cli/daemon.py
@@ -335,10 +335,15 @@ class Daemon:
                 logger.info("Buildarr ready.")
 
     def _start_signal_handlers(self) -> None:
-        # Setup SIGINT, SIGTERM, and SIGHUP signal handers.
-        # SIGHUP can be used to reload the configuration, even if watch_config is disabled.
+        """
+        Setup `SIGINT`, `SIGTERM` and `SIGHUP` signal handers.
+
+        SIGHUP can be used to reload the configuration, even if `watch_config` is disabled.
+        """
         logger.info("Setting up signal handlers")
+        logger.debug("Setting up SIGINT signal handler")
         signal.signal(signal.SIGINT, self._sigterm_handler)
+        logger.debug("Setting up SIGTERM signal handler")
         signal.signal(signal.SIGTERM, self._sigterm_handler)
         if hasattr(signal, "SIGHUP"):
             logger.debug("Setting up SIGHUP signal handler")

--- a/buildarr/cli/daemon.py
+++ b/buildarr/cli/daemon.py
@@ -228,6 +228,8 @@ class Daemon:
 
         Push initial updates to their configuration to all defined instances.
         """
+        # Load the latest Buildarr configuration.
+        self._load_config()
         # Print the daemon-specific configuration to the log.
         logger.info("Daemon configuration:")
         logger.info(" - Watch configuration files: %s", "Yes" if self._watch_config else "No")

--- a/buildarr/cli/daemon.py
+++ b/buildarr/cli/daemon.py
@@ -26,7 +26,7 @@ from contextlib import contextmanager
 from datetime import datetime, time
 from logging import getLogger
 from pathlib import Path
-from threading import Lock
+from threading import Lock, current_thread
 from time import sleep
 from typing import TYPE_CHECKING, cast
 
@@ -168,10 +168,13 @@ class Daemon:
         """
         Control Buildarr run jobs using a lock, ensuring only one job runs at a given time.
         """
+        thread = current_thread()
         self._lock.acquire()
         try:
+            logger.debug("Thread '%s' acquired daemon run lock", thread.name)
             yield
         finally:
+            logger.debug("Thread '%s' releasing daemon run lock", thread.name)
             self._lock.release()
 
     def _load_config(self) -> None:


### PR DESCRIPTION
* Perform update job scheduling and configuration file watch registering as soon as the new configuration is loaded
* Only update job schedule and configuration file watching when there are changes
* Add a lock to the daemon to ensure that only one job thread is performing a run at a given time
* Add error handling to the config watcher thread to ensure it stays running even when an unexpected error occurs