### PR TITLE
Add built-in support for handling `NameEmail` attribute types

### DIFF
--- a/buildarr/config/base.py
+++ b/buildarr/config/base.py
@@ -43,7 +43,7 @@ from uuid import UUID
 
 import yaml
 
-from pydantic import AnyUrl, BaseModel, SecretStr
+from pydantic import AnyUrl, BaseModel, NameEmail, SecretStr
 from pydantic.validators import _VALIDATORS
 from typing_extensions import Self
 
@@ -685,6 +685,8 @@ class ConfigBase(BaseModel, Generic[Secrets]):
             return value.to_name_str()
         elif isinstance(value, AnyUrl):
             return str(value)
+        elif isinstance(value, NameEmail):
+            return str(value)
         elif isinstance(value, SecretStr):
             return str(value)
         elif isinstance(value, Path):
@@ -752,6 +754,8 @@ class ConfigBase(BaseModel, Generic[Secrets]):
         if isinstance(value, BaseEnum):
             return value.value
         elif isinstance(value, AnyUrl):
+            return str(value)
+        elif isinstance(value, NameEmail):
             return str(value)
         elif isinstance(value, SecretStr):
             return value.get_secret_value()


### PR DESCRIPTION
Decode, encode and format `NameEmail` type attributes correctly for most applications.

This fixes uses of the attribute type in plugins that do not provide explicit encoding/decoding for this type.

This will not be done for every possible type, but `NameEmail` is common and generic enough that it makes the cut.