### PR TITLE
Allow any configuration value to be defined in any file

### DIFF
--- a/buildarr/config/base.py
+++ b/buildarr/config/base.py
@@ -22,7 +22,7 @@ from __future__ import annotations
 import json
 
 from logging import getLogger
-from pathlib import Path, PurePath
+from pathlib import Path, PurePath, PurePosixPath, PureWindowsPath
 from typing import (
     Any,
     Callable,
@@ -825,4 +825,10 @@ class ConfigBase(BaseModel, Generic[Secrets]):
 
 
 # Add custom validators which are not provided by Pydantic.
-_VALIDATORS.append((PurePath, [lambda v: PurePath(v)]))
+_VALIDATORS.extend(
+    [
+        (PurePath, [lambda v: PurePath(v)]),
+        (PurePosixPath, [lambda v: PurePosixPath(v)]),
+        (PureWindowsPath, [lambda v: PureWindowsPath(v)]),
+    ],
+)

--- a/buildarr/config/base.py
+++ b/buildarr/config/base.py
@@ -22,7 +22,7 @@ from __future__ import annotations
 import json
 
 from logging import getLogger
-from pathlib import Path, PurePosixPath
+from pathlib import Path, PurePath
 from typing import (
     Any,
     Callable,
@@ -824,19 +824,5 @@ class ConfigBase(BaseModel, Generic[Secrets]):
         pass
 
 
-def _validate_pure_posix_path(v: Any) -> PurePosixPath:
-    """
-    PurePosixPath default object validator for Pydantic.
-
-    Args:
-        v (Any): Value to validate
-
-    Returns:
-        PurePosixPath object
-    """
-
-    return PurePosixPath(v)
-
-
-# Add the PurePosixPath validator to the list of Pyadantic validators.
-_VALIDATORS.append((PurePosixPath, [_validate_pure_posix_path]))
+# Add custom validators which are not provided by Pydantic.
+_VALIDATORS.append((PurePath, [lambda v: PurePath(v)]))

--- a/buildarr/config/base.py
+++ b/buildarr/config/base.py
@@ -27,7 +27,6 @@ from typing import (
     Any,
     Callable,
     Dict,
-    Generator,
     Generic,
     Iterable,
     List,
@@ -44,13 +43,12 @@ from uuid import UUID
 
 import yaml
 
-from pydantic import AnyUrl, BaseModel, NameEmail, SecretStr, root_validator
+from pydantic import AnyUrl, BaseModel, NameEmail, SecretStr
 from pydantic.validators import _VALIDATORS
 from typing_extensions import Self
 
 from ..plugins import Secrets
-from ..state import state
-from ..types import BaseEnum, LocalPath, ModelConfigBase
+from ..types import BaseEnum, ModelConfigBase
 from .types import RemoteMapEntry
 
 logger = getLogger(__name__)
@@ -791,37 +789,6 @@ class ConfigBase(BaseModel, Generic[Secrets]):
             json.loads(self.json(*args, **kwargs)),
             **{**(yaml_kwargs or {}), "sort_keys": sort_keys},
         )
-
-    @root_validator
-    def _validate_localpaths(cls, values: Dict[str, Any]) -> Dict[str, Any]:
-        """
-        Set the default value for `hostname` on instance-specific configurations.
-
-        The `instances` value on the global (default instance) configuration is left alone.
-
-        Args:
-            values (Dict[str, Any]): Input values for all local fields
-
-        Returns:
-            Dict[str, Any]: Changed field structure
-        """
-        for key, value in values.items():
-            if cls.__fields__[key].type_ is LocalPath:
-                values[key] = LocalPath(value)
-        return values
-
-    @classmethod
-    def __get_validators__(cls) -> Generator[Callable[[Any], Self], None, None]:
-        """
-        Pass class validation functions to Pydantic.
-
-        Yields:
-            Validation class functions
-        """
-        if state._only_validate_localpaths:
-            yield cls._validate_localpaths
-        else:
-            yield from super().__get_validators__()
 
     class Config(ModelConfigBase):
         """

--- a/buildarr/config/buildarr.py
+++ b/buildarr/config/buildarr.py
@@ -25,7 +25,7 @@ from datetime import time
 from pathlib import Path
 from typing import Set
 
-from pydantic import AnyHttpUrl, PositiveFloat
+from pydantic import AnyHttpUrl, Field, PositiveFloat
 
 from ..types import DayOfWeek, LocalPath, NonEmptyStr
 from .base import ConfigBase
@@ -116,7 +116,7 @@ class BuildarrConfig(ConfigBase):
     This configuration option can be overridden using the `--update-times` command line argument.
     """
 
-    secrets_file_path: LocalPath = LocalPath("secrets.json")
+    secrets_file_path: LocalPath = Field(default_factory=lambda: LocalPath("secrets.json"))
     """
     Path to store the Buildarr instance secrets file.
 

--- a/buildarr/config/buildarr.py
+++ b/buildarr/config/buildarr.py
@@ -116,7 +116,7 @@ class BuildarrConfig(ConfigBase):
     This configuration option can be overridden using the `--update-times` command line argument.
     """
 
-    secrets_file_path: LocalPath = LocalPath("secrets.json")
+    secrets_file_path: LocalPath = "secrets.json"  # type: ignore[assignment]
     """
     Path to store the Buildarr instance secrets file.
 
@@ -149,7 +149,7 @@ class BuildarrConfig(ConfigBase):
     URL to download the latest TRaSH-Guides metadata from.
     """
 
-    trash_metadata_dir_prefix: Path = Path("Guides-master")
+    trash_metadata_dir_prefix: Path = "Guides-master"  # type: ignore[assignment]
     """
     Metadata directory name within the downloaded ZIP file.
     """

--- a/buildarr/config/buildarr.py
+++ b/buildarr/config/buildarr.py
@@ -25,7 +25,7 @@ from datetime import time
 from pathlib import Path
 from typing import Set
 
-from pydantic import AnyHttpUrl, Field, PositiveFloat
+from pydantic import AnyHttpUrl, PositiveFloat
 
 from ..types import DayOfWeek, LocalPath, NonEmptyStr
 from .base import ConfigBase
@@ -116,7 +116,7 @@ class BuildarrConfig(ConfigBase):
     This configuration option can be overridden using the `--update-times` command line argument.
     """
 
-    secrets_file_path: LocalPath = Field(default_factory=lambda: LocalPath("secrets.json"))
+    secrets_file_path: LocalPath = LocalPath("secrets.json")
     """
     Path to store the Buildarr instance secrets file.
 

--- a/buildarr/config/load.py
+++ b/buildarr/config/load.py
@@ -117,10 +117,15 @@ def _get_files_and_configs(
         if config is None:
             config = {}
         with state._with_current_dir(path.parent):
-            config_obj = model.construct(**{k: v for k, v in config.items() if k != "includes"})
+            try:
+                state._only_validate_localpaths = True
+                config_obj = model(**{k: v for k, v in config.items() if k != "includes"})
+            finally:
+                state._only_validate_localpaths = False
         configs.append(config_obj.dict(exclude_unset=True))
 
     from pprint import pprint
+
     pprint(configs)
 
     # Check if the YAML object loaded is the correct type.

--- a/buildarr/config/load.py
+++ b/buildarr/config/load.py
@@ -90,7 +90,8 @@ def load_config(path: Path, use_plugins: Optional[Set[str]] = None) -> None:
     logger.debug("Finished merging configuration objects")
 
     logger.debug("Parsing and validating configuration")
-    state.config = model(**config)
+    with state._with_current_dir(path.parent):
+        state.config = model(**config)
     logger.debug("Finished parsing and validating configuration")
 
     state.config_files = files

--- a/buildarr/config/load.py
+++ b/buildarr/config/load.py
@@ -171,9 +171,17 @@ def _expand_relative_paths(
             print(f"Key '{key}' is of type LocalType")
             path = Path(config[key])
             config[key] = path if path.is_absolute() else get_absolute_path(config_dir / path)
-        elif issubclass(field.outer_type_, ConfigBase):
+        try:
+            is_subclass = issubclass(field.outer_type_, ConfigBase)
+        except TypeError:
+            is_subclass = False
+        if is_subclass:
             print(f"Recursing to type {field.type_} for key '{key}'")
-            _expand_relative_paths(config_dir=config_dir, model=field.type_, config=config[key])
+            _expand_relative_paths(
+                config_dir=config_dir,
+                model=field.type_,
+                config=config[key],
+            )
 
 
 def load_instance_configs(use_plugins: Optional[Set[str]] = None) -> None:

--- a/buildarr/config/load.py
+++ b/buildarr/config/load.py
@@ -232,7 +232,7 @@ def _expand_relative_paths(
         return {
             key: _expand_relative_paths(
                 config_dir=config_dir,
-                value_type=field._outer_type,
+                value_type=field.outer_type_,
                 value=value[key],
             )
             for key, field in type_tree[-1].__fields__.items()

--- a/buildarr/config/load.py
+++ b/buildarr/config/load.py
@@ -188,17 +188,20 @@ def _expand_relative_paths(
             absolute_path = get_absolute_path(config_dir / local_path)
             logger.debug("Expanding relative local path '%s' into '%s'", local_path, absolute_path)
             return str(absolute_path)
-    elif type_tree[-1] is Union:
-        attr_union_types = get_type_args(type_tree[-2])
+    if type_tree[-1] is Union:
+        union_types = get_type_args(type_tree[-2])
         if (
-            len(attr_union_types) == OPTIONAL_TYPE_UNION_SIZE
-            and type(None) in attr_union_types
-            and value is not None
+            len(union_types) == OPTIONAL_TYPE_UNION_SIZE
+            and type(None) in union_types
         ):
-            return _expand_relative_paths(
-                config_dir=config_dir,
-                value_type=next(t for t in attr_union_types if t is not type(None)),
-                value=value,
+            return (
+                _expand_relative_paths(
+                    config_dir=config_dir,
+                    value_type=next(t for t in union_types if t is not type(None)),
+                    value=value,
+                )
+                if value is not None
+                else None
             )
     if type_tree[-1] in (list, set):
         element_type = get_type_args(type_tree[-2])[0]

--- a/buildarr/config/load.py
+++ b/buildarr/config/load.py
@@ -117,7 +117,7 @@ def _get_files_and_configs(
         if config is None:
             config = {}
         with state._with_current_dir(path.parent):
-            config_obj = model(**{k: v for k, v in config.items() if k != "includes"})
+            config_obj = model.construct(**{k: v for k, v in config.items() if k != "includes"})
         configs.append(config_obj.dict(exclude_unset=True))
 
     # Check if the YAML object loaded is the correct type.

--- a/buildarr/config/load.py
+++ b/buildarr/config/load.py
@@ -117,13 +117,13 @@ def _get_files_and_configs(
         config: Optional[Dict[str, Any]] = yaml.safe_load(f)
         if config is None:
             config = {}
-        config = {k: v for k, v in config.items() if k != "includes"}
+        config_no_includes = {k: v for k, v in config.items() if k != "includes"}
         _expand_relative_paths(
             config_dir=path.parent,
             model=model,
-            config=config,
+            config=config_no_includes,
         )
-        configs.append(config)
+        configs.append(config_no_includes)
 
     from pprint import pprint
 

--- a/buildarr/config/load.py
+++ b/buildarr/config/load.py
@@ -164,12 +164,14 @@ def _expand_relative_paths(
     # Recursively expand any `LocalPath` type field values in the configuration dictionary
     # that are relative paths.
     for key, field in model.__fields__.items():
+        if key not in config:
+            continue
         print(f"key='{key}', type={field.type_}")
         if field.type_ is LocalPath:
             print(f"Key '{key}' is of type LocalType")
             path = Path(config[key])
             config[key] = path if path.is_absolute() else get_absolute_path(config_dir / path)
-        elif issubclass(ConfigBase, field.type_):
+        elif issubclass(field.type_, ConfigBase):
             print(f"Recursing to type {field.type_} for key '{key}'")
             _expand_relative_paths(config_dir=config_dir, model=field.type_, config=config[key])
 

--- a/buildarr/config/load.py
+++ b/buildarr/config/load.py
@@ -229,11 +229,15 @@ def _expand_relative_paths(
     except TypeError:
         is_subclass = False
     if is_subclass:
-        return _expand_relative_paths(
-            config_dir=config_dir,
-            value_type=type_tree[-1],
-            value=value,
-        )
+        return {
+            key: _expand_relative_paths(
+                config_dir=config_dir,
+                value_type=field._outer_type,
+                value=value[key],
+            )
+            for key, field in type_tree[-1].__fields__.items()
+            if key in value
+        }
     return value
 
 

--- a/buildarr/config/load.py
+++ b/buildarr/config/load.py
@@ -171,7 +171,7 @@ def _expand_relative_paths(
             print(f"Key '{key}' is of type LocalType")
             path = Path(config[key])
             config[key] = path if path.is_absolute() else get_absolute_path(config_dir / path)
-        elif issubclass(field.type_, ConfigBase):
+        elif issubclass(field.outer_type_, ConfigBase):
             print(f"Recursing to type {field.type_} for key '{key}'")
             _expand_relative_paths(config_dir=config_dir, model=field.type_, config=config[key])
 

--- a/buildarr/config/load.py
+++ b/buildarr/config/load.py
@@ -120,6 +120,9 @@ def _get_files_and_configs(
             config_obj = model.construct(**{k: v for k, v in config.items() if k != "includes"})
         configs.append(config_obj.dict(exclude_unset=True))
 
+    from pprint import pprint
+    pprint(configs)
+
     # Check if the YAML object loaded is the correct type.
     if not isinstance(config, dict):
         raise ValueError(

--- a/buildarr/config/load.py
+++ b/buildarr/config/load.py
@@ -24,6 +24,7 @@ from pathlib import Path
 from typing import (
     TYPE_CHECKING,
     Type,
+    Union,
     cast,
     get_args as get_type_args,
     get_origin as get_type_origin,
@@ -41,7 +42,7 @@ from .buildarr import BuildarrConfig
 from .models import ConfigType
 
 if TYPE_CHECKING:
-    from typing import Any, Dict, List, Optional, Set, Tuple, Union
+    from typing import Any, Dict, List, Optional, Set, Tuple
 
     from .models import ConfigPlugin, ConfigPluginType
 
@@ -155,7 +156,11 @@ def _get_files_and_configs(
             )
         for include in includes:
             ip = Path(include)
-            include_path = get_absolute_path(ip if ip.is_absolute() else (path.parent / ip))
+            if ip.is_absolute():
+                include_path = ip
+            else:
+                include_path = get_absolute_path(path.parent / ip)
+                logger.debug("Expanding relative local path '%s' into '%s'", ip, include_path)
             _files, _configs = _get_files_and_configs(model, include_path)
             files.extend(_files)
             configs.extend(_configs)

--- a/buildarr/config/load.py
+++ b/buildarr/config/load.py
@@ -164,6 +164,7 @@ def _expand_relative_paths(
     # Recursively expand any `LocalPath` type field values in the configuration dictionary
     # that are relative paths.
     for key, field in model.__fields__.items():
+        print(f"key='{key}', type={field.type_}")
         if field.type_ is LocalPath:
             print(f"Key '{key}' is of type LocalType")
             path = Path(config[key])

--- a/buildarr/state.py
+++ b/buildarr/state.py
@@ -126,6 +126,12 @@ class State:
     Currently loaded instance secrets.
     """
 
+    _current_dir: Path = Path.cwd()
+    """
+    Current working directory for relative path resolution.
+    This state attribute is internal, and shouldn't be accessed by plugins.
+    """
+
     _current_plugin: str
     """
     The plugin being processed in the current context.
@@ -180,10 +186,24 @@ class State:
         self.active_plugins = None  # type: ignore[assignment]
         self.trash_metadata_dir = None  # type: ignore[assignment]
         self.secrets = None  # type: ignore[assignment]
+        self._current_dir = Path.cwd()
         self._current_plugin = None  # type: ignore[assignment]
         self._current_instance = None  # type: ignore[assignment]
         self._instance_dependencies = defaultdict(set)  # type: ignore[assignment]
         self._execution_order = None  # type: ignore[assignment]
+
+    @contextmanager
+    def _with_current_dir(self, current_dir: Path) -> Generator[None, None, None]:
+        """
+        Set the current directory context within a code block.
+        This state function is internal, and shouldn't be used by plugins.
+        Args:
+            current_dir (Path): Path to use as the current directory.
+        """
+        old_current_dir = self._current_dir
+        self._current_dir = current_dir
+        yield
+        self._current_dir = old_current_dir
 
     @contextmanager
     def _with_context(

--- a/buildarr/state.py
+++ b/buildarr/state.py
@@ -126,13 +126,6 @@ class State:
     Currently loaded instance secrets.
     """
 
-    _current_dir: Path = Path.cwd()
-    """
-    Current working directory for relative path resolution.
-
-    This state attribute is internal, and shouldn't be accessed by plugins.
-    """
-
     _current_plugin: str
     """
     The plugin being processed in the current context.
@@ -187,26 +180,10 @@ class State:
         self.active_plugins = None  # type: ignore[assignment]
         self.trash_metadata_dir = None  # type: ignore[assignment]
         self.secrets = None  # type: ignore[assignment]
-        self._current_dir = Path.cwd()
         self._current_plugin = None  # type: ignore[assignment]
         self._current_instance = None  # type: ignore[assignment]
         self._instance_dependencies = defaultdict(set)  # type: ignore[assignment]
         self._execution_order = None  # type: ignore[assignment]
-
-    @contextmanager
-    def _with_current_dir(self, current_dir: Path) -> Generator[None, None, None]:
-        """
-        Set the current directory context within a code block.
-
-        This state function is internal, and shouldn't be used by plugins.
-
-        Args:
-            current_dir (Path): Path to use as the current directory.
-        """
-        old_current_dir = self._current_dir
-        self._current_dir = current_dir
-        yield
-        self._current_dir = old_current_dir
 
     @contextmanager
     def _with_context(

--- a/buildarr/state.py
+++ b/buildarr/state.py
@@ -133,13 +133,6 @@ class State:
     This state attribute is internal, and shouldn't be accessed by plugins.
     """
 
-    _only_validate_localpaths: bool = False
-    """
-    Whether or not to only validate `LocalPath` attributes when loading configuration.
-
-    This state attribute is internal, and shouldn't be accessed by plugins.
-    """
-
     _current_plugin: str
     """
     The plugin being processed in the current context.
@@ -195,7 +188,6 @@ class State:
         self.trash_metadata_dir = None  # type: ignore[assignment]
         self.secrets = None  # type: ignore[assignment]
         self._current_dir = Path.cwd()
-        self._only_validate_localpaths = False
         self._current_plugin = None  # type: ignore[assignment]
         self._current_instance = None  # type: ignore[assignment]
         self._instance_dependencies = defaultdict(set)  # type: ignore[assignment]

--- a/buildarr/state.py
+++ b/buildarr/state.py
@@ -133,6 +133,13 @@ class State:
     This state attribute is internal, and shouldn't be accessed by plugins.
     """
 
+    _only_validate_localpaths: bool = False
+    """
+    Whether or not to only validate `LocalPath` attributes when loading configuration.
+
+    This state attribute is internal, and shouldn't be accessed by plugins.
+    """
+
     _current_plugin: str
     """
     The plugin being processed in the current context.
@@ -187,6 +194,8 @@ class State:
         self.active_plugins = None  # type: ignore[assignment]
         self.trash_metadata_dir = None  # type: ignore[assignment]
         self.secrets = None  # type: ignore[assignment]
+        self._current_dir = Path.cwd()
+        self._only_validate_localpaths = False
         self._current_plugin = None  # type: ignore[assignment]
         self._current_instance = None  # type: ignore[assignment]
         self._instance_dependencies = defaultdict(set)  # type: ignore[assignment]

--- a/buildarr/types.py
+++ b/buildarr/types.py
@@ -422,31 +422,11 @@ class LocalPath(type(Path()), Path):  # type: ignore[misc]
     `/path/secrets/buildarr.json`, *not* `/opt/secrets/buildarr.json`.
     """
 
-    @classmethod
-    def __get_validators__(cls) -> Generator[Callable[[Any], Self], None, None]:
-        """
-        Pass class validation functions to Pydantic.
-
-        Yields:
-            Validation class functions
-        """
-        yield cls.validate
-
-    @classmethod
-    def validate(cls, value: Any) -> Self:
-        """
-        Validate the local path value, and return an absolute path.
-
-        Args:
-            value (Any): Object to validate and coerce
-
-        Returns:
-            Absolute local path
-        """
-        path = cls(value)
-        if not path.is_absolute():
-            return cls(get_absolute_path(state._current_dir / path))
-        return path
+    def __init__(self, *args) -> None:  # noqa: N804
+        path = Path(*args)
+        super().__init__(
+            get_absolute_path(state._current_dir / path) if not path.is_absolute() else path,
+        )
 
 
 class ModelConfigBase:

--- a/buildarr/types.py
+++ b/buildarr/types.py
@@ -31,7 +31,6 @@ from pydantic.fields import ModelField
 from typing_extensions import Annotated, Self
 
 from .state import state
-from .util import get_absolute_path
 
 if TYPE_CHECKING:
     from .config.models import ConfigPlugin
@@ -423,11 +422,7 @@ class LocalPath(Path):
     """
 
     def __new__(cls, *args, **kwargs):
-        path = Path(*args)
-        return Path.__new__(
-            Path,
-            get_absolute_path(state._current_dir / path) if not path.is_absolute() else path,
-        )
+        return Path.__new__(Path, *args, **args)
 
 
 class ModelConfigBase:

--- a/buildarr/types.py
+++ b/buildarr/types.py
@@ -422,7 +422,7 @@ class LocalPath(Path):
     """
 
     def __new__(cls, *args, **kwargs):
-        return Path.__new__(Path, *args, **args)
+        return Path.__new__(Path, *args, **kwargs)
 
 
 class ModelConfigBase:

--- a/buildarr/types.py
+++ b/buildarr/types.py
@@ -423,11 +423,9 @@ class LocalPath(Path):
     """
 
     def __new__(cls, *args, **kwargs):
-        return Path.__new__(Path, *args, **kwargs)
-
-    def __init__(self, *args):
         path = Path(*args)
-        super().__init__(
+        return Path.__new__(
+            Path,
             get_absolute_path(state._current_dir / path) if not path.is_absolute() else path,
         )
 

--- a/buildarr/types.py
+++ b/buildarr/types.py
@@ -400,7 +400,7 @@ class InstanceName(str):
         return cls(value)
 
 
-class LocalPath(type(Path()), Path):  # type: ignore[misc]
+class LocalPath(Path):
     """
     Model type for a local path.
 
@@ -422,7 +422,10 @@ class LocalPath(type(Path()), Path):  # type: ignore[misc]
     `/path/secrets/buildarr.json`, *not* `/opt/secrets/buildarr.json`.
     """
 
-    def __init__(self, *args) -> None:  # noqa: N804
+    def __new__(cls, *args, **kwargs):
+        return Path.__new__(Path, *args, **kwargs)
+
+    def __init__(self, *args):
         path = Path(*args)
         super().__init__(
             get_absolute_path(state._current_dir / path) if not path.is_absolute() else path,


### PR DESCRIPTION
Change the initial per-file validation of configuration files into a non-validating parsing and expansion of `LocalPath` attributes based on the dynamically generated Pydantic model.

This allows validation of only `LocalPath` type attributes while not validating anything else until the combined configuration structure is loaded properly.

With this change, the limitation where individual configuration files need to be syntatically correct on its own has now been lifted. The combined files being loaded, as a set, being correct is sufficient.