### PR TITLE
Log errors during daemon update runs without exiting

### DIFF
--- a/buildarr/cli/daemon.py
+++ b/buildarr/cli/daemon.py
@@ -224,9 +224,13 @@ class Daemon:
         logger.info("Applying initial configuration")
         try:
             run_apply(secrets_file_path=self._secrets_file_path)
+        except Exception as err:
+            logger.exception("An error occurred while applying initial configuration: %s", err)
+            logger.warning("Aborted applying initial configuration")
+        else:
+            logger.info("Finished applying initial configuration")
         finally:
             state._reset()
-        logger.info("Finished applying initial configuration")
 
     def _setup_update_schedule(self) -> None:
         """
@@ -256,9 +260,16 @@ class Daemon:
             logger.info("Running scheduled update of remote instances")
             try:
                 run_apply(secrets_file_path=self._secrets_file_path)
+            except Exception as err:
+                logger.exception(
+                    "An error occurred while running scheduled update of remote instances: %s",
+                    err,
+                )
+                logger.warning("Aborted running scheduled update of remote instances")
+            else:
+                logger.info("Finished running scheduled update of remote instances")
             finally:
                 state._reset()
-            logger.info("Finished running scheduled update of remote instances")
             self._log_next_run()
             logger.info("Buildarr ready.")
 

--- a/buildarr/cli/daemon.py
+++ b/buildarr/cli/daemon.py
@@ -226,11 +226,11 @@ class Daemon:
             run_apply(secrets_file_path=self._secrets_file_path)
         except Exception as err:
             logger.exception("An error occurred while applying initial configuration: %s", err)
+            state._reset()
             logger.warning("Aborted applying initial configuration")
         else:
-            logger.info("Finished applying initial configuration")
-        finally:
             state._reset()
+            logger.info("Finished applying initial configuration")
 
     def _setup_update_schedule(self) -> None:
         """
@@ -265,11 +265,11 @@ class Daemon:
                     "An error occurred while running scheduled update of remote instances: %s",
                     err,
                 )
+                state._reset()
                 logger.warning("Aborted running scheduled update of remote instances")
             else:
-                logger.info("Finished running scheduled update of remote instances")
-            finally:
                 state._reset()
+                logger.info("Finished running scheduled update of remote instances")
             self._log_next_run()
             logger.info("Buildarr ready.")
 


### PR DESCRIPTION
This resolves the following issues:

* Makes it easier to troubleshoot when using the Docker container, as `docker logs -f` will not exit when the Buildarr process exits
* Eliminates "short cycling", where a Buildarr daemon will continually restart, try the same actions, and fail with the same result
* Makes error handling behaviour consistent between the initial run (which quits) and scheduled update runs (which do not quit on error, even in the current version)