### PR TITLE
Fix the next run time after scheduled runs

### DIFF
--- a/buildarr/cli/daemon.py
+++ b/buildarr/cli/daemon.py
@@ -266,10 +266,15 @@ class Daemon:
         """
         Print a log alerting the user to the next scheduled run time.
         """
-        logger.info(
-            "The next run will be at %s",
-            self._scheduler.next_run.strftime("%Y-%m-%d %H:%M"),
-        )
+        now = datetime.now()
+        for job in sorted(self._scheduler.jobs):
+            if not job.next_run or (job.next_run - now).total_seconds() < 0:
+                continue
+            logger.info(
+                "The next run will be at %s",
+                job.next_run.strftime("%Y-%m-%d %H:%M"),
+            )
+            return
 
     def _setup_watch_config(self) -> None:
         """


### PR DESCRIPTION
Manually traverse the job list, and log the earliest one with a `next_run` time in the future as the next run.