### PR TITLE
Set `read_only` to `true` to Buildarr config in Docker Compose docs

### DIFF
--- a/docs/installation.md
+++ b/docs/installation.md
@@ -114,6 +114,7 @@ services:
       - type: bind
         source: ./buildarr
         target: /config
+        read_only: true
     environment:
       TZ: Pacific/Auckland
       PUID: "1000"


### PR DESCRIPTION
Buildarr no longer requires write access to the mounted `/config` folder, so remove the ability for it to write to it.