### PR TITLE
Fix bugs in multi-value `BaseEnum`

### DIFF
--- a/buildarr/types.py
+++ b/buildarr/types.py
@@ -322,7 +322,7 @@ class BaseEnum(MultiValueEnum):
             for value in obj.values:
                 if (
                     isinstance(value, str)
-                    and obj.values[1].lower().replace("/", "_").replace("-", "_") == name
+                    and value.lower().replace("/", "_").replace("-", "_") == name
                 ):
                     return obj
         raise KeyError(repr(name))


### PR DESCRIPTION
* Fix the value being checked being fixed to the second value when decoding for multi-value `BaseEnum`