### PR TITLE
Replace Black with the Ruff formatter

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -14,16 +14,11 @@ repos:
       - id: detect-private-key
       - id: check-added-large-files
       - id: check-merge-conflict
-  - repo: https://github.com/charliermarsh/ruff-pre-commit
-    rev: "v0.1.5"
+  - repo: https://github.com/astral-sh/ruff-pre-commit
+    rev: "v0.3.0"
     hooks:
       - id: ruff
-        args:
-          - --exit-non-zero-on-fix
-  - repo: https://github.com/psf/black
-    rev: "23.11.0"
-    hooks:
-      - id: black
+      - id: ruff-format
   - repo: https://github.com/pre-commit/mirrors-mypy
     rev: "v1.7.0"
     hooks:

--- a/buildarr/__init__.py
+++ b/buildarr/__init__.py
@@ -16,7 +16,6 @@
 Buildarr root module.
 """
 
-
 from __future__ import annotations
 
 from importlib_metadata import PackageNotFoundError, version as package_version

--- a/buildarr/cli/__init__.py
+++ b/buildarr/cli/__init__.py
@@ -17,7 +17,6 @@ buildarr/cli/__init__.py
 Buildarr command line interface (CLI) global group.
 """
 
-
 from __future__ import annotations
 
 import os

--- a/buildarr/cli/compose.py
+++ b/buildarr/cli/compose.py
@@ -16,7 +16,6 @@
 `buildarr compose` CLI command.
 """
 
-
 from __future__ import annotations
 
 from ipaddress import ip_address

--- a/buildarr/cli/daemon.py
+++ b/buildarr/cli/daemon.py
@@ -16,7 +16,6 @@
 `buildarr daemon` CLI command.
 """
 
-
 from __future__ import annotations
 
 import itertools

--- a/buildarr/cli/exceptions.py
+++ b/buildarr/cli/exceptions.py
@@ -16,7 +16,6 @@
 Buildarr CLI exceptions.
 """
 
-
 from __future__ import annotations
 
 from ..exceptions import BuildarrError

--- a/buildarr/cli/main.py
+++ b/buildarr/cli/main.py
@@ -18,7 +18,6 @@
 Buildarr CLI main routine.
 """
 
-
 from __future__ import annotations
 
 from ..plugins import load as load_plugins

--- a/buildarr/cli/run.py
+++ b/buildarr/cli/run.py
@@ -16,7 +16,6 @@
 `buildarr run` CLI command.
 """
 
-
 from __future__ import annotations
 
 from logging import getLogger

--- a/buildarr/cli/test_config.py
+++ b/buildarr/cli/test_config.py
@@ -16,7 +16,6 @@
 `buildarr test-config` CLI command.
 """
 
-
 from __future__ import annotations
 
 from logging import getLogger

--- a/buildarr/config/__init__.py
+++ b/buildarr/config/__init__.py
@@ -16,7 +16,6 @@
 Buildarr configuration interface.
 """
 
-
 from __future__ import annotations
 
 from .base import ConfigBase

--- a/buildarr/config/base.py
+++ b/buildarr/config/base.py
@@ -16,7 +16,6 @@
 Buildarr configuration base class.
 """
 
-
 from __future__ import annotations
 
 import json
@@ -113,11 +112,12 @@ class ConfigBase(BaseModel, Generic[Secrets]):
 
         if TYPE_CHECKING:
             from .secrets import ExampleSecrets
-            class ExampleConfigBase(ConfigBase[ExampleSecrets]):
-                ...
+
+            class ExampleConfigBase(ConfigBase[ExampleSecrets]): ...
         else:
-            class ExampleConfigBase(ConfigBase):
-                ...
+
+            class ExampleConfigBase(ConfigBase): ...
+
 
         class ExampleConfig(ExampleConfigBase):
             local_attr_1: bool
@@ -137,8 +137,7 @@ class ConfigBase(BaseModel, Generic[Secrets]):
             ]
 
             @classmethod
-            def _api_get(cls, secrets: ExampleSecrets) -> Dict[str, Any]:
-                ...
+            def _api_get(cls, secrets: ExampleSecrets) -> Dict[str, Any]: ...
 
             @classmethod
             def from_remote(cls, secrets: ExampleSecrets) -> Self:
@@ -304,11 +303,12 @@ class ConfigBase(BaseModel, Generic[Secrets]):
 
         if TYPE_CHECKING:
             from .secrets import ExampleSecrets
-            class ExampleConfigBase(ConfigBase[ExampleSecrets]):
-                ...
+
+            class ExampleConfigBase(ConfigBase[ExampleSecrets]): ...
         else:
-            class ExampleConfigBase(ConfigBase):
-                ...
+
+            class ExampleConfigBase(ConfigBase): ...
+
 
         class ExampleObj(ExampleConfigBase):
             obj_attr1: int
@@ -328,11 +328,9 @@ class ConfigBase(BaseModel, Generic[Secrets]):
             ]
 
             @classmethod
-            def _api_post(cls, secrets: ExampleSecrets, obj: Mapping[str, Any]) -> None:
-                ...
+            def _api_post(cls, secrets: ExampleSecrets, obj: Mapping[str, Any]) -> None: ...
 
-            def _exists_on_remote(self, secrets: ExampleSecrets) -> bool:
-                ...
+            def _exists_on_remote(self, secrets: ExampleSecrets) -> bool: ...
 
             def _create_remote(self, secrets: ExampleSecrets) -> None:
                 self._api_post(
@@ -342,6 +340,7 @@ class ConfigBase(BaseModel, Generic[Secrets]):
                         remote_map=self._remote_map,
                     ),
                 )
+
 
         class ExampleConfig(ExampleConfigBase):
             local_objs: Dict[str, ExampleObj]
@@ -466,11 +465,12 @@ class ConfigBase(BaseModel, Generic[Secrets]):
 
         if TYPE_CHECKING:
             from .secrets import ExampleSecrets
-            class ExampleConfigBase(ConfigBase[ExampleSecrets]):
-                ...
+
+            class ExampleConfigBase(ConfigBase[ExampleSecrets]): ...
         else:
-            class ExampleConfigBase(ConfigBase):
-                ...
+
+            class ExampleConfigBase(ConfigBase): ...
+
 
         class ExampleConfig(ExampleConfigBase):
             local_attr_1: bool
@@ -490,8 +490,7 @@ class ConfigBase(BaseModel, Generic[Secrets]):
             ]
 
             @classmethod
-            def _api_put(cls, secrets: Secrets, obj: Mapping[str, Any]) -> None:
-                ...
+            def _api_put(cls, secrets: Secrets, obj: Mapping[str, Any]) -> None: ...
 
             def update_remote(
                 self,
@@ -836,17 +835,17 @@ class ConfigBase(BaseModel, Generic[Secrets]):
 
         if TYPE_CHECKING:
             from .secrets import ExampleSecrets
-            class _ExampleConfig(ConfigBase[ExampleSecrets]):
-                ...
+
+            class _ExampleConfig(ConfigBase[ExampleSecrets]): ...
         else:
-            class _ExampleConfig(ConfigBase):
-                ...
+
+            class _ExampleConfig(ConfigBase): ...
+
 
         class ExampleConfig(_ExampleConfig):
             ...
 
-            class Config(_ExampleConfig.Config):
-                ...  # Add model configuration attributes here.
+            class Config(_ExampleConfig.Config): ...  # Add model configuration attributes here.
         ```
         """
 

--- a/buildarr/config/buildarr.py
+++ b/buildarr/config/buildarr.py
@@ -16,7 +16,6 @@
 Buildarr settings configuration.
 """
 
-
 from __future__ import annotations
 
 import os

--- a/buildarr/config/exceptions.py
+++ b/buildarr/config/exceptions.py
@@ -16,7 +16,6 @@
 Buildarr config exception classes.
 """
 
-
 from __future__ import annotations
 
 from ..exceptions import BuildarrError

--- a/buildarr/config/load.py
+++ b/buildarr/config/load.py
@@ -16,7 +16,6 @@
 Buildarr configuration loading function.
 """
 
-
 from __future__ import annotations
 
 from logging import getLogger

--- a/buildarr/config/models.py
+++ b/buildarr/config/models.py
@@ -16,7 +16,6 @@
 Buildarr plugin configuration object models.
 """
 
-
 from __future__ import annotations
 
 from typing import Any, Dict, Type, cast
@@ -50,11 +49,12 @@ class ConfigPlugin(ConfigBase[Secrets]):
 
     if TYPE_CHECKING:
         from .secrets import ExampleSecrets
-        class _ExampleInstanceConfig(ConfigPlugin[ExampleSecrets]):
-            ...
+
+        class _ExampleInstanceConfig(ConfigPlugin[ExampleSecrets]): ...
     else:
-        class _ExampleInstanceConfig(ConfigPlugin):
-            ...
+
+        class _ExampleInstanceConfig(ConfigPlugin): ...
+
 
     class ExampleInstanceConfig(_ExampleInstanceConfig):
         # Required configuration overrides from `ConfigPlugin`
@@ -65,6 +65,7 @@ class ConfigPlugin(ConfigBase[Secrets]):
         # Custom configuration options go here
         local_value_1: bool = False
         local_value_2: str = "local"
+
 
     class ExampleConfig(ExampleInstanceConfig):
         # Inherit all configuration attributes from the instance-specific config.

--- a/buildarr/config/post_init_render.py
+++ b/buildarr/config/post_init_render.py
@@ -16,7 +16,6 @@
 Post-initialisation configuration rendering stage.
 """
 
-
 from __future__ import annotations
 
 from collections import defaultdict

--- a/buildarr/config/render_instance_configs.py
+++ b/buildarr/config/render_instance_configs.py
@@ -16,7 +16,6 @@
 Buildarr configuration rendering function.
 """
 
-
 from __future__ import annotations
 
 from collections import defaultdict

--- a/buildarr/config/resolve_instance_dependencies.py
+++ b/buildarr/config/resolve_instance_dependencies.py
@@ -16,7 +16,6 @@
 Buildarr configuration instance-to-instance dependency resolution functions.
 """
 
-
 from __future__ import annotations
 
 from typing import TYPE_CHECKING

--- a/buildarr/config/types.py
+++ b/buildarr/config/types.py
@@ -16,7 +16,6 @@
 Type hints for Buildarr configuration models.
 """
 
-
 from __future__ import annotations
 
 from typing import Any, Mapping, Tuple

--- a/buildarr/exceptions.py
+++ b/buildarr/exceptions.py
@@ -16,7 +16,6 @@
 Buildarr exception classes.
 """
 
-
 from __future__ import annotations
 
 

--- a/buildarr/logging.py
+++ b/buildarr/logging.py
@@ -16,7 +16,6 @@
 Buildarr logging functions.
 """
 
-
 from __future__ import annotations
 
 import logging

--- a/buildarr/manager/__init__.py
+++ b/buildarr/manager/__init__.py
@@ -16,7 +16,6 @@
 Buildarr manager interface.
 """
 
-
 from __future__ import annotations
 
 from logging import getLogger
@@ -52,6 +51,7 @@ class ManagerPlugin(Generic[Config, Secrets]):
     from buildarr.manager import ManagerPlugin
     from .config import ExampleConfig
     from .secrets import ExampleSecrets
+
 
     class ExampleManager(ManagerPlugin[ExampleConfig, ExampleSecrets]):
         pass

--- a/buildarr/manager/exceptions.py
+++ b/buildarr/manager/exceptions.py
@@ -16,7 +16,6 @@
 Buildarr manager exception classes.
 """
 
-
 from __future__ import annotations
 
 from ..exceptions import BuildarrError

--- a/buildarr/plugins/__init__.py
+++ b/buildarr/plugins/__init__.py
@@ -16,7 +16,6 @@
 Buildarr plugin specification.
 """
 
-
 from __future__ import annotations
 
 from .load import load

--- a/buildarr/plugins/dummy/api.py
+++ b/buildarr/plugins/dummy/api.py
@@ -16,7 +16,6 @@
 Dummy plugin API functions.
 """
 
-
 from __future__ import annotations
 
 import json

--- a/buildarr/plugins/dummy/cli.py
+++ b/buildarr/plugins/dummy/cli.py
@@ -16,7 +16,6 @@
 Dummy plugin CLI commands.
 """
 
-
 from __future__ import annotations
 
 import functools

--- a/buildarr/plugins/dummy/config/__init__.py
+++ b/buildarr/plugins/dummy/config/__init__.py
@@ -16,7 +16,6 @@
 Dummy plugin configuration.
 """
 
-
 from __future__ import annotations
 
 from typing import TYPE_CHECKING, Dict, Optional
@@ -34,13 +33,11 @@ from .settings import DummySettingsConfig
 # Allow Mypy to properly resolve secrets type declarations in configuration classes.
 if TYPE_CHECKING:
 
-    class _DummyInstanceConfig(ConfigPlugin[DummySecrets]):
-        ...
+    class _DummyInstanceConfig(ConfigPlugin[DummySecrets]): ...
 
 else:
 
-    class _DummyInstanceConfig(ConfigPlugin):
-        ...
+    class _DummyInstanceConfig(ConfigPlugin): ...
 
 
 class DummyInstanceConfig(_DummyInstanceConfig):

--- a/buildarr/plugins/dummy/config/settings.py
+++ b/buildarr/plugins/dummy/config/settings.py
@@ -16,7 +16,6 @@
 Dummy plugin settings configuration.
 """
 
-
 from __future__ import annotations
 
 import json

--- a/buildarr/plugins/dummy/config/types.py
+++ b/buildarr/plugins/dummy/config/types.py
@@ -16,7 +16,6 @@
 Dummy plugin configuration utility classes and functions.
 """
 
-
 from __future__ import annotations
 
 from typing import TYPE_CHECKING

--- a/buildarr/plugins/dummy/exceptions.py
+++ b/buildarr/plugins/dummy/exceptions.py
@@ -16,7 +16,6 @@
 Dummy plugin exception classes.
 """
 
-
 from __future__ import annotations
 
 from buildarr.exceptions import BuildarrError

--- a/buildarr/plugins/dummy/manager.py
+++ b/buildarr/plugins/dummy/manager.py
@@ -16,7 +16,6 @@
 Dummy plugin manager class.
 """
 
-
 from __future__ import annotations
 
 from buildarr.manager import ManagerPlugin

--- a/buildarr/plugins/dummy/plugin.py
+++ b/buildarr/plugins/dummy/plugin.py
@@ -16,7 +16,6 @@
 Dummy plugin interface.
 """
 
-
 from __future__ import annotations
 
 from buildarr import __version__

--- a/buildarr/plugins/dummy/secrets.py
+++ b/buildarr/plugins/dummy/secrets.py
@@ -16,7 +16,6 @@
 Dummy plugin secrets file model.
 """
 
-
 from __future__ import annotations
 
 from http import HTTPStatus

--- a/buildarr/plugins/dummy/server.py
+++ b/buildarr/plugins/dummy/server.py
@@ -29,7 +29,6 @@ This is simply for convenience when testing, to give the Dummy plugin something
 to communicate with for testing purposes.
 """
 
-
 from __future__ import annotations
 
 from typing import TYPE_CHECKING, Mapping, cast
@@ -106,7 +105,7 @@ def get_initialize_json() -> Tuple[Response, int]:
     """
 
     res = {"apiRoot": app.config["API_ROOT"]}
-    if "API_KEY" in app.config and app.config["API_KEY"]:
+    if app.config.get("API_KEY"):
         res["apiKey"] = app.config["API_KEY"]
     res["version"] = __version__
 

--- a/buildarr/plugins/dummy/types.py
+++ b/buildarr/plugins/dummy/types.py
@@ -16,7 +16,6 @@
 Dummy plugin type hints.
 """
 
-
 from __future__ import annotations
 
 from typing import Literal

--- a/buildarr/plugins/load.py
+++ b/buildarr/plugins/load.py
@@ -16,7 +16,6 @@
 Buildarr plugin loading functions.
 """
 
-
 from __future__ import annotations
 
 from logging import getLogger

--- a/buildarr/plugins/models.py
+++ b/buildarr/plugins/models.py
@@ -16,7 +16,6 @@
 Buildarr plugin models.
 """
 
-
 from __future__ import annotations
 
 from typing import TYPE_CHECKING
@@ -43,6 +42,7 @@ class Plugin:
     from buildarr_example.cli import example
     from buildarr_example.config import ExampleConfig
     from buildarr_example.secrets import ExampleSecrets
+
 
     class ExamplePlugin(Plugin):
         cli = example

--- a/buildarr/plugins/types.py
+++ b/buildarr/plugins/types.py
@@ -16,7 +16,6 @@
 Buildarr plugin type hints.
 """
 
-
 from __future__ import annotations
 
 from typing import TYPE_CHECKING, TypeVar

--- a/buildarr/secrets/__init__.py
+++ b/buildarr/secrets/__init__.py
@@ -16,7 +16,6 @@
 Buildarr secrets metadata interface.
 """
 
-
 from __future__ import annotations
 
 from .base import SecretsBase

--- a/buildarr/secrets/base.py
+++ b/buildarr/secrets/base.py
@@ -16,7 +16,6 @@
 Buildarr secrets metadata base class.
 """
 
-
 from __future__ import annotations
 
 from typing import Generic
@@ -51,17 +50,17 @@ class SecretsBase(BaseModel, Generic[Config]):
 
         if TYPE_CHECKING:
             from .config import ExampleConfig
-            class _ExampleSecrets(SecretsBase[ExampleSecrets]):
-                ...
+
+            class _ExampleSecrets(SecretsBase[ExampleSecrets]): ...
         else:
-            class _ExampleSecrets(SecretsBase):
-                ...
+
+            class _ExampleSecrets(SecretsBase): ...
+
 
         class ExampleSecrets(_ExampleSecrets):
             ...
 
-            class Config(_ExampleSecrets.Config):
-                ...  # Add model configuration attributes here.
+            class Config(_ExampleSecrets.Config): ...  # Add model configuration attributes here.
         ```
         """
 

--- a/buildarr/secrets/models.py
+++ b/buildarr/secrets/models.py
@@ -16,7 +16,6 @@
 Buildarr plugin secrets metadata models.
 """
 
-
 from __future__ import annotations
 
 from typing import TYPE_CHECKING
@@ -52,12 +51,13 @@ class SecretsPlugin(SecretsBase[Config]):
 
     if TYPE_CHECKING:
         from typing import Self
-        from  .config import ExampleConfig
-        class _ExampleSecrets(SecretsPlugin[ExampleConfig]):
-            ...
+        from .config import ExampleConfig
+
+        class _ExampleSecrets(SecretsPlugin[ExampleConfig]): ...
     else:
-        class _ExampleSecrets(SecretsPlugin):
-            ...
+
+        class _ExampleSecrets(SecretsPlugin): ...
+
 
     class ExampleSecrets(_ExampleSecrets):
         hostname: NonEmptyStr

--- a/buildarr/state.py
+++ b/buildarr/state.py
@@ -16,7 +16,6 @@
 Buildarr global runtime state.
 """
 
-
 from __future__ import annotations
 
 import os

--- a/buildarr/trash.py
+++ b/buildarr/trash.py
@@ -16,7 +16,6 @@
 Buildarr TRaSH-Guides metadata functions.
 """
 
-
 from __future__ import annotations
 
 from logging import getLogger

--- a/buildarr/types.py
+++ b/buildarr/types.py
@@ -16,7 +16,6 @@
 Buildarr general purpose type hints, used in plugin models.
 """
 
-
 from __future__ import annotations
 
 import re
@@ -64,11 +63,12 @@ class RssUrl(AnyUrl):
 
     if TYPE_CHECKING:
         from .secrets import ExampleSecrets
-        class ExampleConfigBase(ConfigBase[ExampleSecrets]):
-            ...
+
+        class ExampleConfigBase(ConfigBase[ExampleSecrets]): ...
     else:
-        class ExampleConfigBase(ConfigBase):
-            ...
+
+        class ExampleConfigBase(ConfigBase): ...
+
 
     class ExampleConfig(ExampleConfigBase):
         rss_url: RssUrl
@@ -90,11 +90,12 @@ class Port(ConstrainedInt):
 
     if TYPE_CHECKING:
         from .secrets import ExampleSecrets
-        class ExampleConfigBase(ConfigBase[ExampleSecrets]):
-            ...
+
+        class ExampleConfigBase(ConfigBase[ExampleSecrets]): ...
     else:
-        class ExampleConfigBase(ConfigBase):
-            ...
+
+        class ExampleConfigBase(ConfigBase): ...
+
 
     class ExampleConfig(ExampleConfigBase):
         host: NonEmptyStr
@@ -119,6 +120,7 @@ class NonEmptyStr(ConstrainedStr):
     ```python
     from buildarr.config import ConfigBase, NonEmptyStr, Port
 
+
     class ExampleConfig(ConfigBase):
         host: NonEmptyStr
         port: Port
@@ -139,6 +141,7 @@ class LowerCaseStr(ConstrainedStr):
     ```python
     from buildarr.config import LowerCaseStr
 
+
     class ExampleConfig(ConfigBase):
         lowercase_name: LowerCaseStr
     ```
@@ -156,6 +159,7 @@ class LowerCaseNonEmptyStr(LowerCaseStr):
 
     ```python
     from buildarr.config import LowerCaseNonEmptyStr
+
 
     class ExampleConfig(ConfigBase):
         lowercase_name: LowerCaseNonEmptyStr
@@ -176,6 +180,7 @@ class UpperCaseStr(ConstrainedStr):
     ```python
     from buildarr.config import UpperCaseStr
 
+
     class ExampleConfig(ConfigBase):
         uppercase_name: UpperCaseStr
     ```
@@ -193,6 +198,7 @@ class UpperCaseNonEmptyStr(UpperCaseStr):
 
     ```python
     from buildarr.config import UpperCaseNonEmptyStr
+
 
     class ExampleConfig(ConfigBase):
         uppercase_name: UpperCaseNonEmptyStr
@@ -216,11 +222,12 @@ class TrashID(ConstrainedStr):
 
     if TYPE_CHECKING:
         from .secrets import ExampleSecrets
-        class ExampleConfigBase(ConfigBase[ExampleSecrets]):
-            ...
+
+        class ExampleConfigBase(ConfigBase[ExampleSecrets]): ...
     else:
-        class ExampleConfigBase(ConfigBase):
-            ...
+
+        class ExampleConfigBase(ConfigBase): ...
+
 
     class ExampleConfig(ExampleConfigBase):
         trash_id: TrashID
@@ -247,9 +254,11 @@ class BaseEnum(MultiValueEnum):
     from buildarr.config import ConfigBase
     from buildarr.types import BaseEnum
 
+
     class Animal(BaseEnum):
         value_1 = 0
         value_2 = 1
+
 
     class ExampleConfig(ConfigBase):
         animal: Animal
@@ -467,11 +476,12 @@ class InstanceName(str):
 
     if TYPE_CHECKING:
         from .secrets import ExampleSecrets
-        class ExampleConfigBase(ConfigBase[ExampleSecrets]):
-            ...
+
+        class ExampleConfigBase(ConfigBase[ExampleSecrets]): ...
     else:
-        class ExampleConfigBase(ConfigBase):
-            ...
+
+        class ExampleConfigBase(ConfigBase): ...
+
 
     class ExampleConfig(ExampleConfigBase):
         instance_name: Optional[InstanceName] = Field(None, plugin="example")

--- a/buildarr/util.py
+++ b/buildarr/util.py
@@ -16,7 +16,6 @@
 Buildarr general utility functions.
 """
 
-
 from __future__ import annotations
 
 import os

--- a/pdm.lock
+++ b/pdm.lock
@@ -2,10 +2,10 @@
 # It is not intended for manual editing.
 
 [metadata]
-groups = ["default"]
+groups = ["default", "docs", "lint", "test"]
 strategy = ["cross_platform", "inherit_metadata"]
 lock_version = "4.4.1"
-content_hash = "sha256:be30bc529be06831334a5ab919db3c66471b4c7a3909888c3f8dd3924ba3c139"
+content_hash = "sha256:0b20b79900a899d3f7d5f24d773008765deeba7e6db48257036fda10d2936f57"
 
 [[package]]
 name = "aenum"
@@ -15,6 +15,32 @@ groups = ["default"]
 files = [
     {file = "aenum-3.1.15-py3-none-any.whl", hash = "sha256:e0dfaeea4c2bd362144b87377e2c61d91958c5ed0b4daf89cb6f45ae23af6288"},
     {file = "aenum-3.1.15.tar.gz", hash = "sha256:8cbd76cd18c4f870ff39b24284d3ea028fbe8731a58df3aa581e434c575b9559"},
+]
+
+[[package]]
+name = "astunparse"
+version = "1.6.3"
+summary = "An AST unparser for Python"
+groups = ["docs"]
+marker = "python_version < \"3.9\""
+dependencies = [
+    "six<2.0,>=1.6.1",
+    "wheel<1.0,>=0.23.0",
+]
+files = [
+    {file = "astunparse-1.6.3-py2.py3-none-any.whl", hash = "sha256:c2652417f2c8b5bb325c885ae329bdf3f86424075c4fd1a128674bc6fba4b8e8"},
+    {file = "astunparse-1.6.3.tar.gz", hash = "sha256:5ad93a8456f0d084c3456d059fd9a92cce667963232cbf763eac3bc5b7940872"},
+]
+
+[[package]]
+name = "blinker"
+version = "1.7.0"
+requires_python = ">=3.8"
+summary = "Fast, simple object-to-object and broadcast signaling"
+groups = ["test"]
+files = [
+    {file = "blinker-1.7.0-py3-none-any.whl", hash = "sha256:c3f865d4d54db7abc53758a01601cf343fe55b84c1de4e3fa910e420b438d5b9"},
+    {file = "blinker-1.7.0.tar.gz", hash = "sha256:e6820ff6fa4e4d1d8e2747c2283749c3f547e4fee112b98555cdcdae32996182"},
 ]
 
 [[package]]
@@ -119,7 +145,7 @@ name = "click"
 version = "8.1.7"
 requires_python = ">=3.7"
 summary = "Composable command line interface toolkit"
-groups = ["default"]
+groups = ["default", "docs", "test"]
 dependencies = [
     "colorama; platform_system == \"Windows\"",
 ]
@@ -148,8 +174,7 @@ name = "colorama"
 version = "0.4.6"
 requires_python = "!=3.0.*,!=3.1.*,!=3.2.*,!=3.3.*,!=3.4.*,!=3.5.*,!=3.6.*,>=2.7"
 summary = "Cross-platform colored terminal text."
-groups = ["default"]
-marker = "platform_system == \"Windows\""
+groups = ["default", "docs", "test"]
 files = [
     {file = "colorama-0.4.6-py2.py3-none-any.whl", hash = "sha256:4f1d9991f5acc0ca119f9d443620b77f9d6b33703e51011c16baf57afb285fc6"},
     {file = "colorama-0.4.6.tar.gz", hash = "sha256:08695f5cb7ed6e0531a20572697297273c47b8cae5a63ffc6d6ed5c201be6e44"},
@@ -193,6 +218,53 @@ files = [
 ]
 
 [[package]]
+name = "flask"
+version = "3.0.0"
+requires_python = ">=3.8"
+summary = "A simple framework for building complex web applications."
+groups = ["test"]
+dependencies = [
+    "Jinja2>=3.1.2",
+    "Werkzeug>=3.0.0",
+    "blinker>=1.6.2",
+    "click>=8.1.3",
+    "importlib-metadata>=3.6.0; python_version < \"3.10\"",
+    "itsdangerous>=2.1.2",
+]
+files = [
+    {file = "flask-3.0.0-py3-none-any.whl", hash = "sha256:21128f47e4e3b9d597a3e8521a329bf56909b690fcc3fa3e477725aa81367638"},
+    {file = "flask-3.0.0.tar.gz", hash = "sha256:cfadcdb638b609361d29ec22360d6070a77d7463dcb3ab08d2c2f2f168845f58"},
+]
+
+[[package]]
+name = "ghp-import"
+version = "2.1.0"
+summary = "Copy your docs directly to the gh-pages branch."
+groups = ["docs"]
+dependencies = [
+    "python-dateutil>=2.8.1",
+]
+files = [
+    {file = "ghp-import-2.1.0.tar.gz", hash = "sha256:9c535c4c61193c2df8871222567d7fd7e5014d835f97dc7b7439069e2413d343"},
+    {file = "ghp_import-2.1.0-py3-none-any.whl", hash = "sha256:8337dd7b50877f163d4c0289bc1f1c7f127550241988d568c1db512c4324a619"},
+]
+
+[[package]]
+name = "griffe"
+version = "0.41.1"
+requires_python = ">=3.8"
+summary = "Signatures for entire Python programs. Extract the structure, the frame, the skeleton of your project, to generate API documentation or find breaking changes in your API."
+groups = ["docs"]
+dependencies = [
+    "astunparse>=1.6; python_version < \"3.9\"",
+    "colorama>=0.4",
+]
+files = [
+    {file = "griffe-0.41.1-py3-none-any.whl", hash = "sha256:9b71b82d0177a278467ce362827296957f0ca59ff5437ee41a0d6247aee257fa"},
+    {file = "griffe-0.41.1.tar.gz", hash = "sha256:09d12f955004102d7deeec2e1d87d07434fb2d42905d21b4e03c7cbf9cf78754"},
+]
+
+[[package]]
 name = "idna"
 version = "3.6"
 requires_python = ">=3.5"
@@ -208,13 +280,292 @@ name = "importlib-metadata"
 version = "7.0.1"
 requires_python = ">=3.8"
 summary = "Read metadata from Python packages"
-groups = ["default"]
+groups = ["default", "docs", "test"]
 dependencies = [
     "zipp>=0.5",
 ]
 files = [
     {file = "importlib_metadata-7.0.1-py3-none-any.whl", hash = "sha256:4805911c3a4ec7c3966410053e9ec6a1fecd629117df5adee56dfc9432a1081e"},
     {file = "importlib_metadata-7.0.1.tar.gz", hash = "sha256:f238736bb06590ae52ac1fab06a3a9ef1d8dce2b7a35b5ab329371d6c8f5d2cc"},
+]
+
+[[package]]
+name = "itsdangerous"
+version = "2.1.2"
+requires_python = ">=3.7"
+summary = "Safely pass data to untrusted environments and back."
+groups = ["test"]
+files = [
+    {file = "itsdangerous-2.1.2-py3-none-any.whl", hash = "sha256:2c2349112351b88699d8d4b6b075022c0808887cb7ad10069318a8b0bc88db44"},
+    {file = "itsdangerous-2.1.2.tar.gz", hash = "sha256:5dbbc68b317e5e42f327f9021763545dc3fc3bfe22e6deb96aaf1fc38874156a"},
+]
+
+[[package]]
+name = "jinja2"
+version = "3.1.3"
+requires_python = ">=3.7"
+summary = "A very fast and expressive template engine."
+groups = ["docs", "test"]
+dependencies = [
+    "MarkupSafe>=2.0",
+]
+files = [
+    {file = "Jinja2-3.1.3-py3-none-any.whl", hash = "sha256:7d6d50dd97d52cbc355597bd845fabfbac3f551e1f99619e39a35ce8c370b5fa"},
+    {file = "Jinja2-3.1.3.tar.gz", hash = "sha256:ac8bd6544d4bb2c9792bf3a159e80bba8fda7f07e81bc3aed565432d5925ba90"},
+]
+
+[[package]]
+name = "markdown"
+version = "3.5.2"
+requires_python = ">=3.8"
+summary = "Python implementation of John Gruber's Markdown."
+groups = ["docs"]
+dependencies = [
+    "importlib-metadata>=4.4; python_version < \"3.10\"",
+]
+files = [
+    {file = "Markdown-3.5.2-py3-none-any.whl", hash = "sha256:d43323865d89fc0cb9b20c75fc8ad313af307cc087e84b657d9eec768eddeadd"},
+    {file = "Markdown-3.5.2.tar.gz", hash = "sha256:e1ac7b3dc550ee80e602e71c1d168002f062e49f1b11e26a36264dafd4df2ef8"},
+]
+
+[[package]]
+name = "markupsafe"
+version = "2.1.5"
+requires_python = ">=3.7"
+summary = "Safely add untrusted strings to HTML/XML markup."
+groups = ["docs", "test"]
+files = [
+    {file = "MarkupSafe-2.1.5-cp310-cp310-macosx_10_9_universal2.whl", hash = "sha256:a17a92de5231666cfbe003f0e4b9b3a7ae3afb1ec2845aadc2bacc93ff85febc"},
+    {file = "MarkupSafe-2.1.5-cp310-cp310-macosx_10_9_x86_64.whl", hash = "sha256:72b6be590cc35924b02c78ef34b467da4ba07e4e0f0454a2c5907f473fc50ce5"},
+    {file = "MarkupSafe-2.1.5-cp310-cp310-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:e61659ba32cf2cf1481e575d0462554625196a1f2fc06a1c777d3f48e8865d46"},
+    {file = "MarkupSafe-2.1.5-cp310-cp310-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:2174c595a0d73a3080ca3257b40096db99799265e1c27cc5a610743acd86d62f"},
+    {file = "MarkupSafe-2.1.5-cp310-cp310-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:ae2ad8ae6ebee9d2d94b17fb62763125f3f374c25618198f40cbb8b525411900"},
+    {file = "MarkupSafe-2.1.5-cp310-cp310-musllinux_1_1_aarch64.whl", hash = "sha256:075202fa5b72c86ad32dc7d0b56024ebdbcf2048c0ba09f1cde31bfdd57bcfff"},
+    {file = "MarkupSafe-2.1.5-cp310-cp310-musllinux_1_1_i686.whl", hash = "sha256:598e3276b64aff0e7b3451b72e94fa3c238d452e7ddcd893c3ab324717456bad"},
+    {file = "MarkupSafe-2.1.5-cp310-cp310-musllinux_1_1_x86_64.whl", hash = "sha256:fce659a462a1be54d2ffcacea5e3ba2d74daa74f30f5f143fe0c58636e355fdd"},
+    {file = "MarkupSafe-2.1.5-cp310-cp310-win32.whl", hash = "sha256:d9fad5155d72433c921b782e58892377c44bd6252b5af2f67f16b194987338a4"},
+    {file = "MarkupSafe-2.1.5-cp310-cp310-win_amd64.whl", hash = "sha256:bf50cd79a75d181c9181df03572cdce0fbb75cc353bc350712073108cba98de5"},
+    {file = "MarkupSafe-2.1.5-cp311-cp311-macosx_10_9_universal2.whl", hash = "sha256:629ddd2ca402ae6dbedfceeba9c46d5f7b2a61d9749597d4307f943ef198fc1f"},
+    {file = "MarkupSafe-2.1.5-cp311-cp311-macosx_10_9_x86_64.whl", hash = "sha256:5b7b716f97b52c5a14bffdf688f971b2d5ef4029127f1ad7a513973cfd818df2"},
+    {file = "MarkupSafe-2.1.5-cp311-cp311-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:6ec585f69cec0aa07d945b20805be741395e28ac1627333b1c5b0105962ffced"},
+    {file = "MarkupSafe-2.1.5-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:b91c037585eba9095565a3556f611e3cbfaa42ca1e865f7b8015fe5c7336d5a5"},
+    {file = "MarkupSafe-2.1.5-cp311-cp311-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:7502934a33b54030eaf1194c21c692a534196063db72176b0c4028e140f8f32c"},
+    {file = "MarkupSafe-2.1.5-cp311-cp311-musllinux_1_1_aarch64.whl", hash = "sha256:0e397ac966fdf721b2c528cf028494e86172b4feba51d65f81ffd65c63798f3f"},
+    {file = "MarkupSafe-2.1.5-cp311-cp311-musllinux_1_1_i686.whl", hash = "sha256:c061bb86a71b42465156a3ee7bd58c8c2ceacdbeb95d05a99893e08b8467359a"},
+    {file = "MarkupSafe-2.1.5-cp311-cp311-musllinux_1_1_x86_64.whl", hash = "sha256:3a57fdd7ce31c7ff06cdfbf31dafa96cc533c21e443d57f5b1ecc6cdc668ec7f"},
+    {file = "MarkupSafe-2.1.5-cp311-cp311-win32.whl", hash = "sha256:397081c1a0bfb5124355710fe79478cdbeb39626492b15d399526ae53422b906"},
+    {file = "MarkupSafe-2.1.5-cp311-cp311-win_amd64.whl", hash = "sha256:2b7c57a4dfc4f16f7142221afe5ba4e093e09e728ca65c51f5620c9aaeb9a617"},
+    {file = "MarkupSafe-2.1.5-cp312-cp312-macosx_10_9_universal2.whl", hash = "sha256:8dec4936e9c3100156f8a2dc89c4b88d5c435175ff03413b443469c7c8c5f4d1"},
+    {file = "MarkupSafe-2.1.5-cp312-cp312-macosx_10_9_x86_64.whl", hash = "sha256:3c6b973f22eb18a789b1460b4b91bf04ae3f0c4234a0a6aa6b0a92f6f7b951d4"},
+    {file = "MarkupSafe-2.1.5-cp312-cp312-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:ac07bad82163452a6884fe8fa0963fb98c2346ba78d779ec06bd7a6262132aee"},
+    {file = "MarkupSafe-2.1.5-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:f5dfb42c4604dddc8e4305050aa6deb084540643ed5804d7455b5df8fe16f5e5"},
+    {file = "MarkupSafe-2.1.5-cp312-cp312-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:ea3d8a3d18833cf4304cd2fc9cbb1efe188ca9b5efef2bdac7adc20594a0e46b"},
+    {file = "MarkupSafe-2.1.5-cp312-cp312-musllinux_1_1_aarch64.whl", hash = "sha256:d050b3361367a06d752db6ead6e7edeb0009be66bc3bae0ee9d97fb326badc2a"},
+    {file = "MarkupSafe-2.1.5-cp312-cp312-musllinux_1_1_i686.whl", hash = "sha256:bec0a414d016ac1a18862a519e54b2fd0fc8bbfd6890376898a6c0891dd82e9f"},
+    {file = "MarkupSafe-2.1.5-cp312-cp312-musllinux_1_1_x86_64.whl", hash = "sha256:58c98fee265677f63a4385256a6d7683ab1832f3ddd1e66fe948d5880c21a169"},
+    {file = "MarkupSafe-2.1.5-cp312-cp312-win32.whl", hash = "sha256:8590b4ae07a35970728874632fed7bd57b26b0102df2d2b233b6d9d82f6c62ad"},
+    {file = "MarkupSafe-2.1.5-cp312-cp312-win_amd64.whl", hash = "sha256:823b65d8706e32ad2df51ed89496147a42a2a6e01c13cfb6ffb8b1e92bc910bb"},
+    {file = "MarkupSafe-2.1.5-cp38-cp38-macosx_10_9_universal2.whl", hash = "sha256:656f7526c69fac7f600bd1f400991cc282b417d17539a1b228617081106feb4a"},
+    {file = "MarkupSafe-2.1.5-cp38-cp38-macosx_10_9_x86_64.whl", hash = "sha256:97cafb1f3cbcd3fd2b6fbfb99ae11cdb14deea0736fc2b0952ee177f2b813a46"},
+    {file = "MarkupSafe-2.1.5-cp38-cp38-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:1f3fbcb7ef1f16e48246f704ab79d79da8a46891e2da03f8783a5b6fa41a9532"},
+    {file = "MarkupSafe-2.1.5-cp38-cp38-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:fa9db3f79de01457b03d4f01b34cf91bc0048eb2c3846ff26f66687c2f6d16ab"},
+    {file = "MarkupSafe-2.1.5-cp38-cp38-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:ffee1f21e5ef0d712f9033568f8344d5da8cc2869dbd08d87c84656e6a2d2f68"},
+    {file = "MarkupSafe-2.1.5-cp38-cp38-musllinux_1_1_aarch64.whl", hash = "sha256:5dedb4db619ba5a2787a94d877bc8ffc0566f92a01c0ef214865e54ecc9ee5e0"},
+    {file = "MarkupSafe-2.1.5-cp38-cp38-musllinux_1_1_i686.whl", hash = "sha256:30b600cf0a7ac9234b2638fbc0fb6158ba5bdcdf46aeb631ead21248b9affbc4"},
+    {file = "MarkupSafe-2.1.5-cp38-cp38-musllinux_1_1_x86_64.whl", hash = "sha256:8dd717634f5a044f860435c1d8c16a270ddf0ef8588d4887037c5028b859b0c3"},
+    {file = "MarkupSafe-2.1.5-cp38-cp38-win32.whl", hash = "sha256:daa4ee5a243f0f20d528d939d06670a298dd39b1ad5f8a72a4275124a7819eff"},
+    {file = "MarkupSafe-2.1.5-cp38-cp38-win_amd64.whl", hash = "sha256:619bc166c4f2de5caa5a633b8b7326fbe98e0ccbfacabd87268a2b15ff73a029"},
+    {file = "MarkupSafe-2.1.5-cp39-cp39-macosx_10_9_universal2.whl", hash = "sha256:7a68b554d356a91cce1236aa7682dc01df0edba8d043fd1ce607c49dd3c1edcf"},
+    {file = "MarkupSafe-2.1.5-cp39-cp39-macosx_10_9_x86_64.whl", hash = "sha256:db0b55e0f3cc0be60c1f19efdde9a637c32740486004f20d1cff53c3c0ece4d2"},
+    {file = "MarkupSafe-2.1.5-cp39-cp39-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:3e53af139f8579a6d5f7b76549125f0d94d7e630761a2111bc431fd820e163b8"},
+    {file = "MarkupSafe-2.1.5-cp39-cp39-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:17b950fccb810b3293638215058e432159d2b71005c74371d784862b7e4683f3"},
+    {file = "MarkupSafe-2.1.5-cp39-cp39-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:4c31f53cdae6ecfa91a77820e8b151dba54ab528ba65dfd235c80b086d68a465"},
+    {file = "MarkupSafe-2.1.5-cp39-cp39-musllinux_1_1_aarch64.whl", hash = "sha256:bff1b4290a66b490a2f4719358c0cdcd9bafb6b8f061e45c7a2460866bf50c2e"},
+    {file = "MarkupSafe-2.1.5-cp39-cp39-musllinux_1_1_i686.whl", hash = "sha256:bc1667f8b83f48511b94671e0e441401371dfd0f0a795c7daa4a3cd1dde55bea"},
+    {file = "MarkupSafe-2.1.5-cp39-cp39-musllinux_1_1_x86_64.whl", hash = "sha256:5049256f536511ee3f7e1b3f87d1d1209d327e818e6ae1365e8653d7e3abb6a6"},
+    {file = "MarkupSafe-2.1.5-cp39-cp39-win32.whl", hash = "sha256:00e046b6dd71aa03a41079792f8473dc494d564611a8f89bbbd7cb93295ebdcf"},
+    {file = "MarkupSafe-2.1.5-cp39-cp39-win_amd64.whl", hash = "sha256:fa173ec60341d6bb97a89f5ea19c85c5643c1e7dedebc22f5181eb73573142c5"},
+    {file = "MarkupSafe-2.1.5.tar.gz", hash = "sha256:d283d37a890ba4c1ae73ffadf8046435c76e7bc2247bbb63c00bd1a709c6544b"},
+]
+
+[[package]]
+name = "mergedeep"
+version = "1.3.4"
+requires_python = ">=3.6"
+summary = "A deep merge function for 🐍."
+groups = ["docs"]
+files = [
+    {file = "mergedeep-1.3.4-py3-none-any.whl", hash = "sha256:70775750742b25c0d8f36c55aed03d24c3384d17c951b3175d898bd778ef0307"},
+    {file = "mergedeep-1.3.4.tar.gz", hash = "sha256:0096d52e9dad9939c3d975a774666af186eda617e6ca84df4c94dec30004f2a8"},
+]
+
+[[package]]
+name = "mkdocs"
+version = "1.5.3"
+requires_python = ">=3.7"
+summary = "Project documentation with Markdown."
+groups = ["docs"]
+dependencies = [
+    "click>=7.0",
+    "colorama>=0.4; platform_system == \"Windows\"",
+    "ghp-import>=1.0",
+    "importlib-metadata>=4.3; python_version < \"3.10\"",
+    "jinja2>=2.11.1",
+    "markdown>=3.2.1",
+    "markupsafe>=2.0.1",
+    "mergedeep>=1.3.4",
+    "packaging>=20.5",
+    "pathspec>=0.11.1",
+    "platformdirs>=2.2.0",
+    "pyyaml-env-tag>=0.1",
+    "pyyaml>=5.1",
+    "watchdog>=2.0",
+]
+files = [
+    {file = "mkdocs-1.5.3-py3-none-any.whl", hash = "sha256:3b3a78e736b31158d64dbb2f8ba29bd46a379d0c6e324c2246c3bc3d2189cfc1"},
+    {file = "mkdocs-1.5.3.tar.gz", hash = "sha256:eb7c99214dcb945313ba30426c2451b735992c73c2e10838f76d09e39ff4d0e2"},
+]
+
+[[package]]
+name = "mkdocs-autorefs"
+version = "1.0.1"
+requires_python = ">=3.8"
+summary = "Automatically link across pages in MkDocs."
+groups = ["docs"]
+dependencies = [
+    "Markdown>=3.3",
+    "markupsafe>=2.0.1",
+    "mkdocs>=1.1",
+]
+files = [
+    {file = "mkdocs_autorefs-1.0.1-py3-none-any.whl", hash = "sha256:aacdfae1ab197780fb7a2dac92ad8a3d8f7ca8049a9cbe56a4218cd52e8da570"},
+    {file = "mkdocs_autorefs-1.0.1.tar.gz", hash = "sha256:f684edf847eced40b570b57846b15f0bf57fb93ac2c510450775dcf16accb971"},
+]
+
+[[package]]
+name = "mkdocstrings"
+version = "0.23.0"
+requires_python = ">=3.8"
+summary = "Automatic documentation from sources, for MkDocs."
+groups = ["docs"]
+dependencies = [
+    "Jinja2>=2.11.1",
+    "Markdown>=3.3",
+    "MarkupSafe>=1.1",
+    "importlib-metadata>=4.6; python_version < \"3.10\"",
+    "mkdocs-autorefs>=0.3.1",
+    "mkdocs>=1.2",
+    "pymdown-extensions>=6.3",
+    "typing-extensions>=4.1; python_version < \"3.10\"",
+]
+files = [
+    {file = "mkdocstrings-0.23.0-py3-none-any.whl", hash = "sha256:051fa4014dfcd9ed90254ae91de2dbb4f24e166347dae7be9a997fe16316c65e"},
+    {file = "mkdocstrings-0.23.0.tar.gz", hash = "sha256:d9c6a37ffbe7c14a7a54ef1258c70b8d394e6a33a1c80832bce40b9567138d1c"},
+]
+
+[[package]]
+name = "mkdocstrings-python"
+version = "1.8.0"
+requires_python = ">=3.8"
+summary = "A Python handler for mkdocstrings."
+groups = ["docs"]
+dependencies = [
+    "griffe>=0.37",
+    "mkdocstrings>=0.20",
+]
+files = [
+    {file = "mkdocstrings_python-1.8.0-py3-none-any.whl", hash = "sha256:4209970cc90bec194568682a535848a8d8489516c6ed4adbe58bbc67b699ca9d"},
+    {file = "mkdocstrings_python-1.8.0.tar.gz", hash = "sha256:1488bddf50ee42c07d9a488dddc197f8e8999c2899687043ec5dd1643d057192"},
+]
+
+[[package]]
+name = "mkdocstrings"
+version = "0.23.0"
+extras = ["python"]
+requires_python = ">=3.8"
+summary = "Automatic documentation from sources, for MkDocs."
+groups = ["docs"]
+dependencies = [
+    "mkdocstrings-python>=0.5.2",
+    "mkdocstrings==0.23.0",
+]
+files = [
+    {file = "mkdocstrings-0.23.0-py3-none-any.whl", hash = "sha256:051fa4014dfcd9ed90254ae91de2dbb4f24e166347dae7be9a997fe16316c65e"},
+    {file = "mkdocstrings-0.23.0.tar.gz", hash = "sha256:d9c6a37ffbe7c14a7a54ef1258c70b8d394e6a33a1c80832bce40b9567138d1c"},
+]
+
+[[package]]
+name = "mypy"
+version = "1.7.0"
+requires_python = ">=3.8"
+summary = "Optional static typing for Python"
+groups = ["lint"]
+dependencies = [
+    "mypy-extensions>=1.0.0",
+    "tomli>=1.1.0; python_version < \"3.11\"",
+    "typing-extensions>=4.1.0",
+]
+files = [
+    {file = "mypy-1.7.0-cp310-cp310-macosx_10_9_x86_64.whl", hash = "sha256:5da84d7bf257fd8f66b4f759a904fd2c5a765f70d8b52dde62b521972a0a2357"},
+    {file = "mypy-1.7.0-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:a3637c03f4025f6405737570d6cbfa4f1400eb3c649317634d273687a09ffc2f"},
+    {file = "mypy-1.7.0-cp310-cp310-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:b633f188fc5ae1b6edca39dae566974d7ef4e9aaaae00bc36efe1f855e5173ac"},
+    {file = "mypy-1.7.0-cp310-cp310-musllinux_1_1_x86_64.whl", hash = "sha256:d6ed9a3997b90c6f891138e3f83fb8f475c74db4ccaa942a1c7bf99e83a989a1"},
+    {file = "mypy-1.7.0-cp310-cp310-win_amd64.whl", hash = "sha256:1fe46e96ae319df21359c8db77e1aecac8e5949da4773c0274c0ef3d8d1268a9"},
+    {file = "mypy-1.7.0-cp311-cp311-macosx_10_9_x86_64.whl", hash = "sha256:df67fbeb666ee8828f675fee724cc2cbd2e4828cc3df56703e02fe6a421b7401"},
+    {file = "mypy-1.7.0-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:a79cdc12a02eb526d808a32a934c6fe6df07b05f3573d210e41808020aed8b5d"},
+    {file = "mypy-1.7.0-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:f65f385a6f43211effe8c682e8ec3f55d79391f70a201575def73d08db68ead1"},
+    {file = "mypy-1.7.0-cp311-cp311-musllinux_1_1_x86_64.whl", hash = "sha256:0e81ffd120ee24959b449b647c4b2fbfcf8acf3465e082b8d58fd6c4c2b27e46"},
+    {file = "mypy-1.7.0-cp311-cp311-win_amd64.whl", hash = "sha256:f29386804c3577c83d76520abf18cfcd7d68264c7e431c5907d250ab502658ee"},
+    {file = "mypy-1.7.0-cp312-cp312-macosx_10_9_x86_64.whl", hash = "sha256:87c076c174e2c7ef8ab416c4e252d94c08cd4980a10967754f91571070bf5fbe"},
+    {file = "mypy-1.7.0-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:6cb8d5f6d0fcd9e708bb190b224089e45902cacef6f6915481806b0c77f7786d"},
+    {file = "mypy-1.7.0-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:d93e76c2256aa50d9c82a88e2f569232e9862c9982095f6d54e13509f01222fc"},
+    {file = "mypy-1.7.0-cp312-cp312-musllinux_1_1_x86_64.whl", hash = "sha256:cddee95dea7990e2215576fae95f6b78a8c12f4c089d7e4367564704e99118d3"},
+    {file = "mypy-1.7.0-cp312-cp312-win_amd64.whl", hash = "sha256:d01921dbd691c4061a3e2ecdbfbfad029410c5c2b1ee88946bf45c62c6c91210"},
+    {file = "mypy-1.7.0-cp38-cp38-macosx_10_9_x86_64.whl", hash = "sha256:185cff9b9a7fec1f9f7d8352dff8a4c713b2e3eea9c6c4b5ff7f0edf46b91e41"},
+    {file = "mypy-1.7.0-cp38-cp38-macosx_11_0_arm64.whl", hash = "sha256:7a7b1e399c47b18feb6f8ad4a3eef3813e28c1e871ea7d4ea5d444b2ac03c418"},
+    {file = "mypy-1.7.0-cp38-cp38-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:fc9fe455ad58a20ec68599139ed1113b21f977b536a91b42bef3ffed5cce7391"},
+    {file = "mypy-1.7.0-cp38-cp38-musllinux_1_1_x86_64.whl", hash = "sha256:d0fa29919d2e720c8dbaf07d5578f93d7b313c3e9954c8ec05b6d83da592e5d9"},
+    {file = "mypy-1.7.0-cp38-cp38-win_amd64.whl", hash = "sha256:2b53655a295c1ed1af9e96b462a736bf083adba7b314ae775563e3fb4e6795f5"},
+    {file = "mypy-1.7.0-cp39-cp39-macosx_10_9_x86_64.whl", hash = "sha256:c1b06b4b109e342f7dccc9efda965fc3970a604db70f8560ddfdee7ef19afb05"},
+    {file = "mypy-1.7.0-cp39-cp39-macosx_11_0_arm64.whl", hash = "sha256:bf7a2f0a6907f231d5e41adba1a82d7d88cf1f61a70335889412dec99feeb0f8"},
+    {file = "mypy-1.7.0-cp39-cp39-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:551d4a0cdcbd1d2cccdcc7cb516bb4ae888794929f5b040bb51aae1846062901"},
+    {file = "mypy-1.7.0-cp39-cp39-musllinux_1_1_x86_64.whl", hash = "sha256:55d28d7963bef00c330cb6461db80b0b72afe2f3c4e2963c99517cf06454e665"},
+    {file = "mypy-1.7.0-cp39-cp39-win_amd64.whl", hash = "sha256:870bd1ffc8a5862e593185a4c169804f2744112b4a7c55b93eb50f48e7a77010"},
+    {file = "mypy-1.7.0-py3-none-any.whl", hash = "sha256:96650d9a4c651bc2a4991cf46f100973f656d69edc7faf91844e87fe627f7e96"},
+    {file = "mypy-1.7.0.tar.gz", hash = "sha256:1e280b5697202efa698372d2f39e9a6713a0395a756b1c6bd48995f8d72690dc"},
+]
+
+[[package]]
+name = "mypy-extensions"
+version = "1.0.0"
+requires_python = ">=3.5"
+summary = "Type system extensions for programs checked with the mypy type checker."
+groups = ["lint"]
+files = [
+    {file = "mypy_extensions-1.0.0-py3-none-any.whl", hash = "sha256:4392f6c0eb8a5668a69e23d168ffa70f0be9ccfd32b5cc2d26a34ae5b844552d"},
+    {file = "mypy_extensions-1.0.0.tar.gz", hash = "sha256:75dbf8955dc00442a438fc4d0666508a9a97b6bd41aa2f0ffe9d2f2725af0782"},
+]
+
+[[package]]
+name = "packaging"
+version = "23.2"
+requires_python = ">=3.7"
+summary = "Core utilities for Python packages"
+groups = ["docs"]
+files = [
+    {file = "packaging-23.2-py3-none-any.whl", hash = "sha256:8c491190033a9af7e1d931d0b5dacc2ef47509b34dd0de67ed209b5203fc88c7"},
+    {file = "packaging-23.2.tar.gz", hash = "sha256:048fb0e9405036518eaaf48a55953c750c11e1a1b68e0dd1a9d62ed0c092cfc5"},
+]
+
+[[package]]
+name = "pathspec"
+version = "0.12.1"
+requires_python = ">=3.8"
+summary = "Utility library for gitignore style pattern matching of file paths."
+groups = ["docs"]
+files = [
+    {file = "pathspec-0.12.1-py3-none-any.whl", hash = "sha256:a0d503e138a4c123b27490a4f7beda6a01c6f288df0e4a8b79c7eb0dc7b4cc08"},
+    {file = "pathspec-0.12.1.tar.gz", hash = "sha256:a482d51503a1ab33b1c67a6c3813a26953dbdc71c31dacaef9a838c4e29f5712"},
 ]
 
 [[package]]
@@ -226,6 +577,17 @@ groups = ["default"]
 files = [
     {file = "pbr-6.0.0-py2.py3-none-any.whl", hash = "sha256:4a7317d5e3b17a3dccb6a8cfe67dab65b20551404c52c8ed41279fa4f0cb4cda"},
     {file = "pbr-6.0.0.tar.gz", hash = "sha256:d1377122a5a00e2f940ee482999518efe16d745d423a670c27773dfbc3c9a7d9"},
+]
+
+[[package]]
+name = "platformdirs"
+version = "4.2.0"
+requires_python = ">=3.8"
+summary = "A small Python package for determining appropriate platform-specific dirs, e.g. a \"user data dir\"."
+groups = ["docs"]
+files = [
+    {file = "platformdirs-4.2.0-py3-none-any.whl", hash = "sha256:0614df2a2f37e1a662acbd8e2b25b92ccf8632929bc6d43467e17fe89c75e068"},
+    {file = "platformdirs-4.2.0.tar.gz", hash = "sha256:ef0cc731df711022c174543cb70a9b5bd22e5a9337c8624ef2c2ceb8ddad8768"},
 ]
 
 [[package]]
@@ -315,11 +677,40 @@ files = [
 ]
 
 [[package]]
+name = "pymdown-extensions"
+version = "10.7"
+requires_python = ">=3.8"
+summary = "Extension pack for Python Markdown."
+groups = ["docs"]
+dependencies = [
+    "markdown>=3.5",
+    "pyyaml",
+]
+files = [
+    {file = "pymdown_extensions-10.7-py3-none-any.whl", hash = "sha256:6ca215bc57bc12bf32b414887a68b810637d039124ed9b2e5bd3325cbb2c050c"},
+    {file = "pymdown_extensions-10.7.tar.gz", hash = "sha256:c0d64d5cf62566f59e6b2b690a4095c931107c250a8c8e1351c1de5f6b036deb"},
+]
+
+[[package]]
+name = "python-dateutil"
+version = "2.9.0.post0"
+requires_python = "!=3.0.*,!=3.1.*,!=3.2.*,>=2.7"
+summary = "Extensions to the standard Python datetime module"
+groups = ["docs"]
+dependencies = [
+    "six>=1.5",
+]
+files = [
+    {file = "python-dateutil-2.9.0.post0.tar.gz", hash = "sha256:37dd54208da7e1cd875388217d5e00ebd4179249f90fb72437e91a35459a0ad3"},
+    {file = "python_dateutil-2.9.0.post0-py2.py3-none-any.whl", hash = "sha256:a8b2bc7bffae282281c8140a97d3aa9c14da0b136dfe83f850eea9a5f7470427"},
+]
+
+[[package]]
 name = "pyyaml"
 version = "6.0.1"
 requires_python = ">=3.6"
 summary = "YAML parser and emitter for Python"
-groups = ["default"]
+groups = ["default", "docs"]
 files = [
     {file = "PyYAML-6.0.1-cp310-cp310-macosx_10_9_x86_64.whl", hash = "sha256:d858aa552c999bc8a8d57426ed01e40bef403cd8ccdd0fc5f6f04a00414cac2a"},
     {file = "PyYAML-6.0.1-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:fd66fc5d0da6d9815ba2cebeb4205f95818ff4b79c3ebe268e75d961704af52f"},
@@ -363,6 +754,20 @@ files = [
 ]
 
 [[package]]
+name = "pyyaml-env-tag"
+version = "0.1"
+requires_python = ">=3.6"
+summary = "A custom YAML tag for referencing environment variables in YAML files. "
+groups = ["docs"]
+dependencies = [
+    "pyyaml",
+]
+files = [
+    {file = "pyyaml_env_tag-0.1-py3-none-any.whl", hash = "sha256:af31106dec8a4d68c60207c1886031cbf839b68aa7abccdb19868200532c2069"},
+    {file = "pyyaml_env_tag-0.1.tar.gz", hash = "sha256:70092675bda14fdec33b31ba77e7543de9ddc88f2e5b99160396572d11525bdb"},
+]
+
+[[package]]
 name = "requests"
 version = "2.31.0"
 requires_python = ">=3.7"
@@ -380,6 +785,32 @@ files = [
 ]
 
 [[package]]
+name = "ruff"
+version = "0.3.0"
+requires_python = ">=3.7"
+summary = "An extremely fast Python linter and code formatter, written in Rust."
+groups = ["lint"]
+files = [
+    {file = "ruff-0.3.0-py3-none-macosx_10_12_x86_64.macosx_11_0_arm64.macosx_10_12_universal2.whl", hash = "sha256:7deb528029bacf845bdbb3dbb2927d8ef9b4356a5e731b10eef171e3f0a85944"},
+    {file = "ruff-0.3.0-py3-none-macosx_10_12_x86_64.whl", hash = "sha256:e1e0d4381ca88fb2b73ea0766008e703f33f460295de658f5467f6f229658c19"},
+    {file = "ruff-0.3.0-py3-none-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:2f7dbba46e2827dfcb0f0cc55fba8e96ba7c8700e0a866eb8cef7d1d66c25dcb"},
+    {file = "ruff-0.3.0-py3-none-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:23dbb808e2f1d68eeadd5f655485e235c102ac6f12ad31505804edced2a5ae77"},
+    {file = "ruff-0.3.0-py3-none-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:3ef655c51f41d5fa879f98e40c90072b567c666a7114fa2d9fe004dffba00932"},
+    {file = "ruff-0.3.0-py3-none-manylinux_2_17_ppc64.manylinux2014_ppc64.whl", hash = "sha256:d0d3d7ef3d4f06433d592e5f7d813314a34601e6c5be8481cccb7fa760aa243e"},
+    {file = "ruff-0.3.0-py3-none-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:b08b356d06a792e49a12074b62222f9d4ea2a11dca9da9f68163b28c71bf1dd4"},
+    {file = "ruff-0.3.0-py3-none-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:9343690f95710f8cf251bee1013bf43030072b9f8d012fbed6ad702ef70d360a"},
+    {file = "ruff-0.3.0-py3-none-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:a1f3ed501a42f60f4dedb7805fa8d4534e78b4e196f536bac926f805f0743d49"},
+    {file = "ruff-0.3.0-py3-none-musllinux_1_2_aarch64.whl", hash = "sha256:cc30a9053ff2f1ffb505a585797c23434d5f6c838bacfe206c0e6cf38c921a1e"},
+    {file = "ruff-0.3.0-py3-none-musllinux_1_2_armv7l.whl", hash = "sha256:5da894a29ec018a8293d3d17c797e73b374773943e8369cfc50495573d396933"},
+    {file = "ruff-0.3.0-py3-none-musllinux_1_2_i686.whl", hash = "sha256:755c22536d7f1889be25f2baf6fedd019d0c51d079e8417d4441159f3bcd30c2"},
+    {file = "ruff-0.3.0-py3-none-musllinux_1_2_x86_64.whl", hash = "sha256:dd73fe7f4c28d317855da6a7bc4aa29a1500320818dd8f27df95f70a01b8171f"},
+    {file = "ruff-0.3.0-py3-none-win32.whl", hash = "sha256:19eacceb4c9406f6c41af806418a26fdb23120dfe53583df76d1401c92b7c14b"},
+    {file = "ruff-0.3.0-py3-none-win_amd64.whl", hash = "sha256:128265876c1d703e5f5e5a4543bd8be47c73a9ba223fd3989d4aa87dd06f312f"},
+    {file = "ruff-0.3.0-py3-none-win_arm64.whl", hash = "sha256:e3a4a6d46aef0a84b74fcd201a4401ea9a6cd85614f6a9435f2d33dd8cefbf83"},
+    {file = "ruff-0.3.0.tar.gz", hash = "sha256:0886184ba2618d815067cf43e005388967b67ab9c80df52b32ec1152ab49f53a"},
+]
+
+[[package]]
 name = "schedule"
 version = "1.2.1"
 requires_python = ">=3.7"
@@ -388,6 +819,17 @@ groups = ["default"]
 files = [
     {file = "schedule-1.2.1-py2.py3-none-any.whl", hash = "sha256:14cdeb083a596aa1de6dc77639a1b2ac8bf6eaafa82b1c9279d3612823063d01"},
     {file = "schedule-1.2.1.tar.gz", hash = "sha256:843bc0538b99c93f02b8b50e3e39886c06f2d003b24f48e1aa4cadfa3f341279"},
+]
+
+[[package]]
+name = "six"
+version = "1.16.0"
+requires_python = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*"
+summary = "Python 2 and 3 compatibility utilities"
+groups = ["docs"]
+files = [
+    {file = "six-1.16.0-py2.py3-none-any.whl", hash = "sha256:8abb2f1d86890a2dfb989f9a77cfcfd3e47c2a354b01111771326f8aa26e0254"},
+    {file = "six-1.16.0.tar.gz", hash = "sha256:1e61c37477a1626458e36f7b1d82aa5c9b094fa4802892072e49de9c60c4c926"},
 ]
 
 [[package]]
@@ -405,11 +847,47 @@ files = [
 ]
 
 [[package]]
+name = "tomli"
+version = "2.0.1"
+requires_python = ">=3.7"
+summary = "A lil' TOML parser"
+groups = ["lint"]
+marker = "python_version < \"3.11\""
+files = [
+    {file = "tomli-2.0.1-py3-none-any.whl", hash = "sha256:939de3e7a6161af0c887ef91b7d41a53e7c5a1ca976325f429cb46ea9bc30ecc"},
+    {file = "tomli-2.0.1.tar.gz", hash = "sha256:de526c12914f0c550d15924c62d72abc48d6fe7364aa87328337a31007fe8a4f"},
+]
+
+[[package]]
+name = "types-pyyaml"
+version = "6.0.12.12"
+summary = "Typing stubs for PyYAML"
+groups = ["lint"]
+files = [
+    {file = "types-PyYAML-6.0.12.12.tar.gz", hash = "sha256:334373d392fde0fdf95af5c3f1661885fa10c52167b14593eb856289e1855062"},
+    {file = "types_PyYAML-6.0.12.12-py3-none-any.whl", hash = "sha256:c05bc6c158facb0676674b7f11fe3960db4f389718e19e62bd2b84d6205cfd24"},
+]
+
+[[package]]
+name = "types-requests"
+version = "2.31.0.10"
+requires_python = ">=3.7"
+summary = "Typing stubs for requests"
+groups = ["lint"]
+dependencies = [
+    "urllib3>=2",
+]
+files = [
+    {file = "types-requests-2.31.0.10.tar.gz", hash = "sha256:dc5852a76f1eaf60eafa81a2e50aefa3d1f015c34cf0cba130930866b1b22a92"},
+    {file = "types_requests-2.31.0.10-py3-none-any.whl", hash = "sha256:b32b9a86beffa876c0c3ac99a4cd3b8b51e973fb8e3bd4e0a6bb32c7efad80fc"},
+]
+
+[[package]]
 name = "typing-extensions"
 version = "4.10.0"
 requires_python = ">=3.8"
 summary = "Backported and Experimental Type Hints for Python 3.8+"
-groups = ["default"]
+groups = ["default", "docs", "lint"]
 files = [
     {file = "typing_extensions-4.10.0-py3-none-any.whl", hash = "sha256:69b1a937c3a517342112fb4c6df7e72fc39a38e7891a5730ed4985b5214b5475"},
     {file = "typing_extensions-4.10.0.tar.gz", hash = "sha256:b0abd7c89e8fb96f98db18d86106ff1d90ab692004eb746cf6eda2682f91b3cb"},
@@ -420,7 +898,7 @@ name = "urllib3"
 version = "2.2.1"
 requires_python = ">=3.8"
 summary = "HTTP library with thread-safe connection pooling, file post, and more."
-groups = ["default"]
+groups = ["default", "lint"]
 files = [
     {file = "urllib3-2.2.1-py3-none-any.whl", hash = "sha256:450b20ec296a467077128bff42b73080516e71b56ff59a60a02bef2232c4fa9d"},
     {file = "urllib3-2.2.1.tar.gz", hash = "sha256:d0570876c61ab9e520d776c38acbbb5b05a776d3f9ff98a5c8fd5162a444cf19"},
@@ -444,7 +922,7 @@ name = "watchdog"
 version = "4.0.0"
 requires_python = ">=3.8"
 summary = "Filesystem events monitoring"
-groups = ["default"]
+groups = ["default", "docs"]
 files = [
     {file = "watchdog-4.0.0-cp310-cp310-macosx_10_9_universal2.whl", hash = "sha256:39cb34b1f1afbf23e9562501673e7146777efe95da24fab5707b88f7fb11649b"},
     {file = "watchdog-4.0.0-cp310-cp310-macosx_10_9_x86_64.whl", hash = "sha256:c522392acc5e962bcac3b22b9592493ffd06d1fc5d755954e6be9f4990de932b"},
@@ -478,11 +956,37 @@ files = [
 ]
 
 [[package]]
+name = "werkzeug"
+version = "3.0.1"
+requires_python = ">=3.8"
+summary = "The comprehensive WSGI web application library."
+groups = ["test"]
+dependencies = [
+    "MarkupSafe>=2.1.1",
+]
+files = [
+    {file = "werkzeug-3.0.1-py3-none-any.whl", hash = "sha256:90a285dc0e42ad56b34e696398b8122ee4c681833fb35b8334a095d82c56da10"},
+    {file = "werkzeug-3.0.1.tar.gz", hash = "sha256:507e811ecea72b18a404947aded4b3390e1db8f826b494d76550ef45bb3b1dcc"},
+]
+
+[[package]]
+name = "wheel"
+version = "0.42.0"
+requires_python = ">=3.7"
+summary = "A built-package format for Python"
+groups = ["docs"]
+marker = "python_version < \"3.9\""
+files = [
+    {file = "wheel-0.42.0-py3-none-any.whl", hash = "sha256:177f9c9b0d45c47873b619f5b650346d632cdc35fb5e4d25058e09c9e581433d"},
+    {file = "wheel-0.42.0.tar.gz", hash = "sha256:c45be39f7882c9d34243236f2d63cbd58039e360f85d0913425fbd7ceea617a8"},
+]
+
+[[package]]
 name = "zipp"
 version = "3.17.0"
 requires_python = ">=3.8"
 summary = "Backport of pathlib-compatible object wrapper for zip files"
-groups = ["default"]
+groups = ["default", "docs", "test"]
 files = [
     {file = "zipp-3.17.0-py3-none-any.whl", hash = "sha256:0e923e726174922dce09c53c59ad483ff7bbb8e572e00c7f7c46b88556409f31"},
     {file = "zipp-3.17.0.tar.gz", hash = "sha256:84e64a1c28cf7e91ed2078bb8cc8c259cb19b76942096c8d7b84947690cabaf0"},

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -67,23 +67,37 @@ dummy = "buildarr.plugins.dummy.plugin:DummyPlugin"
 [tool.setuptools_scm]
 
 [tool.pdm.dev-dependencies]
-dev = [
-    "black==23.11.0",
-    "mypy==1.7.0",
-    "types-pyyaml==6.0.12.12",
-    "types-requests==2.31.0.10",
+docs = [
     "mkdocs==1.5.3",
     "mkdocstrings[python]==0.23.0",
+]
+lint = [
+    "mypy==1.7.0",
+    "ruff==0.3.0",
+    "types-pyyaml==6.0.12.12",
+    "types-requests==2.31.0.10",
+]
+test = [
     "flask==3.0.0",
     "werkzeug==3.0.1",
-    "ruff==0.1.5",
 ]
 
 [tool.ruff]
 fix = true
+indent-width = 4
+line-length = 100
 output-format = "grouped"
 target-version = "py38"
-line-length = 100
+
+[tool.ruff.format]
+docstring-code-format = true
+docstring-code-line-length = "dynamic"
+indent-style = "space"
+line-ending = "auto"
+quote-style = "double"
+skip-magic-trailing-comma = false
+
+[tool.ruff.lint]
 select = [
     "A",
     "B",
@@ -119,16 +133,13 @@ extend-ignore = [
     "RUF012",
 ]
 
-[tool.ruff.per-file-ignores]
-"buildarr/cli/main.py" = ["F401"]
-
-[tool.ruff.isort]
+[tool.ruff.lint.isort]
 lines-between-types = 1
 combine-as-imports = true
 required-imports = ["from __future__ import annotations"]
 
-[tool.black]
-line_length = 100
+[tool.ruff.lint.per-file-ignores]
+"buildarr/cli/main.py" = ["F401"]
 
 [tool.mypy]
 python_version = "3.8"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -120,7 +120,14 @@ select = [
     "W",
     "YTT",
 ]
-extend-select = ["COM812", "COM818", "UP009"]
+extend-select = [
+    # COM012 is currently disabled due to a conflict with the Ruff formatter.
+    # https://github.com/astral-sh/ruff/issues/9216
+    # TODO: Decide whether to enable or remove.
+    # "COM812",
+    "COM818",
+    "UP009",
+]
 extend-ignore = [
     "A003",
     "B023",


### PR DESCRIPTION
* Update Ruff to v0.3.0.
* Change Ruff configuration to stop using deprecated structures.
* Split PDM dev dependencies into separate groups based on their use case, and list them in alphabetical order.
* Update the Ruff pre-commit hook to use the official pre-commit repository (which is the original repository we were using, just moved).
* Run Ruff formatter in the pre-commit hooks.
* Remove Black from the development dependencies and pre-commit hooks.
* Update source files with changes from the Ruff formatter. Non-functional, except for one condition optimisation.