### PR TITLE
Improve volume handling in the `buildarr compose` command

### DIFF
--- a/buildarr/cli/compose.py
+++ b/buildarr/cli/compose.py
@@ -331,4 +331,4 @@ def compose(
     if volumes:
         compose_obj["volumes"] = list(volumes)
 
-    click.echo(yaml.safe_dump(compose_obj, explicit_start=True, sort_keys=False))
+    click.echo(yaml.safe_dump(compose_obj, explicit_start=True, sort_keys=False), nl=False)

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -285,13 +285,17 @@ services:
   sonarr_sonarr-hd:
     image: lscr.io/linuxserver/sonarr:latest
     volumes:
-      sonarr_sonarr-hd: /config
+      - type: volume
+        source: sonarr_sonarr-hd
+        target: /config
     hostname: sonarr-hd
     restart: always
   sonarr_sonarr-4k:
     image: lscr.io/linuxserver/sonarr:latest
     volumes:
-      sonarr_sonarr-4k: /config
+      - type: volume
+        source: sonarr_sonarr-4k
+        target: /config
     hostname: sonarr-4k
     restart: always
     depends_on:
@@ -305,6 +309,7 @@ services:
     - type: bind
       source: /opt/buildarr
       target: /config
+      read_only: true
     restart: always
     depends_on:
     - sonarr_sonarr-hd


### PR DESCRIPTION
* Allow plugins to define volumes as a list of [short-syntax strings](https://docs.docker.com/compose/compose-file/05-services/#short-syntax-5), or a list of [long-syntax dictionaries](https://docs.docker.com/compose/compose-file/05-services/#long-syntax-5), in addition to the currently used simple mapping format.
* Convert all supported service volume formats into the "list of long-syntax dictionaries" format in the output Docker Compose file.
* Make troubleshooting easier for the user when two services share the same hostname, by outputting the specific instance defined under the specific plugin that was clashed with (instead of the service name in the output Docker Compose file, which the user won't have).
* Remove extra newline from the end of the `buildarr compose` command output.
* Add new options to the `dummy` plugin for testing the new feaures.