### PR TITLE
Allow execution as a module

### DIFF
--- a/buildarr/__main__.py
+++ b/buildarr/__main__.py
@@ -1,0 +1,7 @@
+# Allow execution of buildarr as a module: python3 -m buildarr
+from __future__ import annotations
+
+from buildarr.cli.main import main
+
+if __name__ == "__main__":
+    main()  # pylint: disable=no-value-for-parameter


### PR DESCRIPTION
This patch allow executing `python3 -m buildarr` which is very handy
way to run when scripts folder might now be available or in PATH.
Most python tools that are CLIs do implement it.
